### PR TITLE
Fix mobile menu overlay, remove noisy preloads, and harden /api/views fallbacks

### DIFF
--- a/src/__tests__/api/views.test.ts
+++ b/src/__tests__/api/views.test.ts
@@ -106,7 +106,7 @@ describe('Views API Route', () => {
       expect(data.success).toBe(false);
     });
 
-    it('returns 500 on database error', async () => {
+    it('returns 200 with zero views on database error (graceful fallback)', async () => {
       mockSupabase.single.mockResolvedValue({
         data: null,
         error: { code: 'DB_ERROR', message: 'Connection failed' },
@@ -116,9 +116,8 @@ describe('Views API Route', () => {
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe('Failed to fetch views');
-      expect(data.success).toBe(false);
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ data: { slug: 'test-post', views: 0 }, success: true });
     });
 
     it('returns all views with titles when all=true', async () => {

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -38,7 +38,8 @@ const handleGet = async (req: NextRequest) => {
 
     if (error && !isNoRowsError(error)) {
       logError("View Counter: Database error", error, { component: 'views', action: 'GET' });
-      return ApiErrors.internalError("Failed to fetch views");
+      // Graceful fallback so blog pages still render even if views storage is unavailable
+      return apiSuccess({ slug, views: 0 });
     }
 
     const views = data?.count || 0;
@@ -122,7 +123,8 @@ const handleOptions = async () => {
 
     if (error) {
       logError("View Counter: Database error", error, { component: 'views', action: 'OPTIONS' });
-      return ApiErrors.internalError("Failed to fetch views");
+      // Graceful fallback for public stats widgets
+      return apiSuccess({ views: [], total: 0 });
     }
 
     // Fetch all blog metadata to get real titles

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -86,10 +86,6 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
         <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossOrigin="anonymous" />
 
-        {/* Preload Critical Resources */}
-        <link rel="preload" href="/images/portrait.webp" as="image" />
-        <link rel="preload" href="/fonts/CalSans-SemiBold.woff2" as="font" crossOrigin="anonymous" />
-
         {/* Canonical Link - Client Component for dynamic pathname */}
         <CanonicalLink />
 
@@ -121,8 +117,6 @@ export default function RootLayout({
           id="google-adsense"
         />
 
-        {/* Resource Hints */}
-        <link rel="modulepreload" href="/_next/static/chunks/main.js" />
       </head>
       <body>
         {/* Skip to content link for accessibility */}

--- a/src/components/ui/mobile-navbar.tsx
+++ b/src/components/ui/mobile-navbar.tsx
@@ -21,7 +21,7 @@ export function MobileNavbar() {
   return (
     <>
       {/* Mobile Menu Button */}
-      <div className="fixed top-0 right-0 z-[200] p-4 md:hidden">
+      <div className="fixed top-0 right-0 z-[450] p-4 md:hidden">
         <motion.button
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -45,7 +45,7 @@ export function MobileNavbar() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-[150] flex flex-col bg-background md:hidden overflow-y-auto"
+            className="fixed inset-0 z-[400] flex flex-col bg-background/95 backdrop-blur-sm md:hidden overflow-y-auto"
           >
             <div className="flex flex-col w-full max-w-md mx-auto p-6 pt-20 space-y-2">
               {/* Category Sections */}

--- a/src/components/ui/tabs-primitive.tsx
+++ b/src/components/ui/tabs-primitive.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+
+type Orientation = "horizontal" | "vertical"
+
+type TabsContextValue = {
+  value?: string
+  setValue: (value: string) => void
+  orientation: Orientation
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null)
+
+function useTabsContext(component: string) {
+  const context = React.useContext(TabsContext)
+  if (!context) {
+    throw new Error(`${component} must be used within Tabs.Root`)
+  }
+  return context
+}
+
+interface RootProps extends React.ComponentPropsWithoutRef<"div"> {
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+  orientation?: Orientation
+}
+
+const Root = React.forwardRef<HTMLDivElement, RootProps>(
+  ({ value: valueProp, defaultValue, onValueChange, orientation = "horizontal", ...props }, ref) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const isControlled = valueProp !== undefined
+    const value = isControlled ? valueProp : internalValue
+
+    const setValue = React.useCallback(
+      (nextValue: string) => {
+        if (!isControlled) {
+          setInternalValue(nextValue)
+        }
+        onValueChange?.(nextValue)
+      },
+      [isControlled, onValueChange]
+    )
+
+    return (
+      <TabsContext.Provider value={{ value, setValue, orientation }}>
+        <div ref={ref} data-orientation={orientation} {...props} />
+      </TabsContext.Provider>
+    )
+  }
+)
+Root.displayName = "TabsRoot"
+
+type ListProps = React.ComponentPropsWithoutRef<"div">
+
+const List = React.forwardRef<HTMLDivElement, ListProps>(({ ...props }, ref) => {
+  const { orientation } = useTabsContext("Tabs.List")
+  return <div ref={ref} role="tablist" aria-orientation={orientation} data-orientation={orientation} {...props} />
+})
+List.displayName = "TabsList"
+
+interface TriggerProps extends React.ComponentPropsWithoutRef<"button"> {
+  value: string
+}
+
+const Trigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
+  ({ value, onClick, ...props }, ref) => {
+    const { value: activeValue, setValue, orientation } = useTabsContext("Tabs.Trigger")
+    const state = activeValue === value ? "active" : "inactive"
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        data-state={state}
+        data-orientation={orientation}
+        aria-selected={state === "active"}
+        onClick={(event) => {
+          setValue(value)
+          onClick?.(event)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+Trigger.displayName = "TabsTrigger"
+
+interface ContentProps extends React.ComponentPropsWithoutRef<"div"> {
+  value: string
+}
+
+const Content = React.forwardRef<HTMLDivElement, ContentProps>(({ value, ...props }, ref) => {
+  const { value: activeValue, orientation } = useTabsContext("Tabs.Content")
+  const isActive = activeValue === value
+
+  return (
+    <div
+      ref={ref}
+      role="tabpanel"
+      data-state={isActive ? "active" : "inactive"}
+      data-orientation={orientation}
+      hidden={!isActive}
+      {...props}
+    />
+  )
+})
+Content.displayName = "TabsContent"
+
+export { Root, List, Trigger, Content }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as TabsPrimitive from "./tabs-primitive"
 import { cva, type VariantProps } from "class-variance-authority"
 import { motion } from "framer-motion"
 

--- a/src/types/static-assets.d.ts
+++ b/src/types/static-assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.webp" {
+  const src: string
+  export default src
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,7 +38,10 @@ const config: Config = {
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
       colors: {
-        primary: "hsl(var(--primary))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
         secondary: "hsl(var(--secondary))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    "**/*.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
### Motivation
- Address visual regression where the mobile navigation allowed page content to bleed through and looked transparent. 
- Eliminate noisy browser console warnings and 404s caused by manual head preloads and a hardcoded module preload. 
- Prevent user-facing 500s from the public views endpoints when the view store is temporarily unavailable.

### Description
- Increased mobile menu z-index and added an opaque blurred background to the mobile overlay so page content no longer shows through (updated `src/components/ui/mobile-navbar.tsx`).
- Removed manual `<link rel="preload">` entries and the hardcoded `/_next/static/chunks/main.js` module preload from the document head to stop preload warnings and 404s (updated `src/app/layout.tsx`).
- Hardened the `/api/views` read paths to return graceful fallback payloads (`views: 0` or empty lists) instead of returning 500 on read errors, and preserved error logging for diagnostics (updated `src/app/api/views/route.ts`).
- Added a small local `Tabs` primitive and switched imports to it, added static asset typings for `.webp`, and ensured Tailwind/TypeScript config picks up `.d.ts` and the restored `primary` token shape (files added/updated: `src/components/ui/tabs-primitive.tsx`, `src/components/ui/tabs.tsx`, `src/types/static-assets.d.ts`, `tailwind.config.ts`, `tsconfig.json`).
- Updated the API unit test to assert the new graceful fallback behavior for GET view-count DB failures (updated `src/__tests__/api/views.test.ts`).

### Testing
- Ran `bun run typecheck` (`tsc --noEmit`) and it passed.
- Ran `bun run test src/__tests__/api/views.test.ts` and all tests passed (11/11).
- Ran `bun run build` which still fails in this environment due to an external Google Fonts fetch for `Manrope` and is an environment/network issue, not a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862daecdd48320861461f349cc6f99)