### PR TITLE
Remove green gradients from home cards and logo assets

### DIFF
--- a/public/images/logos-modern/blog-ai.svg
+++ b/public/images/logos-modern/blog-ai.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">BA</text>
+</svg>

--- a/public/images/logos-modern/eyebook-reader.svg
+++ b/public/images/logos-modern/eyebook-reader.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F59E0B"/>
+      <stop offset="1" stop-color="#EF4444"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">ER</text>
+</svg>

--- a/public/images/logos-modern/find-my-doggo.svg
+++ b/public/images/logos-modern/find-my-doggo.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F43F5E"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">FD</text>
+</svg>

--- a/public/images/logos-modern/leetcode-solver.svg
+++ b/public/images/logos-modern/leetcode-solver.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">LS</text>
+</svg>

--- a/public/images/logos-modern/linkflame.svg
+++ b/public/images/logos-modern/linkflame.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">LF</text>
+</svg>

--- a/public/images/logos-modern/paper-summarizer.svg
+++ b/public/images/logos-modern/paper-summarizer.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">PS</text>
+</svg>

--- a/public/images/logos-modern/talker.svg
+++ b/public/images/logos-modern/talker.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EC4899"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">TK</text>
+</svg>

--- a/public/images/logos-modern/trading-bot.svg
+++ b/public/images/logos-modern/trading-bot.svg
@@ -1,0 +1,17 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="400" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 60) rotate(130) scale(300 260)">
+      <stop stop-color="white" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="36" fill="url(#bg)"/>
+  <rect x="28" y="28" width="584" height="344" rx="26" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <circle cx="140" cy="324" r="130" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="560" cy="96" r="170" fill="url(#glow)"/>
+  <text x="320" y="225" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="132" font-weight="700" fill="white" letter-spacing="6">TB</text>
+</svg>

--- a/src/components/home/recent-blogs.tsx
+++ b/src/components/home/recent-blogs.tsx
@@ -8,6 +8,7 @@ import { Section, SectionHeader } from "../ui/Section";
 import { useRef } from "react";
 import { BlogViewCount } from "../blog/blog-view-count";
 import { showContainerVariants, showItemVariants } from "@/lib/animations";
+import Image from "next/image";
 
 interface BlogPost {
   title: string;
@@ -46,46 +47,60 @@ export function RecentBlogs({ blogs }: RecentBlogsProps) {
           variants={showContainerVariants}
           initial="hidden"
           animate={isInView ? "show" : "hidden"}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+          className="grid grid-cols-1 gap-6 md:grid-cols-6"
         >
-          {blogs.map((post) => (
+          {blogs.map((post, index) => (
             <motion.div
               key={post.slug}
               variants={showItemVariants}
-              className="group relative flex flex-col overflow-hidden rounded-xl bg-secondary/50 transition-all hover:bg-secondary/70"
+              className={`group relative overflow-hidden rounded-2xl border border-border/60 bg-background/95 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl ${
+                index === 0 ? "md:col-span-4" : "md:col-span-2"
+              }`}
             >
-              <Link href={`/blog/${post.slug}`} className="flex flex-col flex-1 p-6">
-                <div className="flex items-center gap-3 text-sm text-muted-foreground mb-3">
-                  <div className="flex items-center gap-2">
-                    <Calendar className="size-4" />
-                    <time dateTime={post.date}>{post.date}</time>
+              <Link href={`/blog/${post.slug}`} className="flex h-full flex-col">
+                <div className="relative h-44 overflow-hidden md:h-52">
+                  <Image
+                    src={post.image || "/images/blog/default.webp"}
+                    alt={post.title}
+                    fill
+                    className="object-cover transition-transform duration-700 group-hover:scale-105"
+                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 66vw, 40vw"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/20 to-transparent" />
+                  <div className="absolute bottom-4 left-4 right-4 flex items-center justify-between text-xs text-white/90">
+                    <div className="flex items-center gap-1.5">
+                      <Calendar className="size-3.5" />
+                      <time dateTime={post.date}>{post.date}</time>
+                    </div>
+                    <BlogViewCount slug={post.slug} />
                   </div>
-                  <BlogViewCount slug={post.slug} />
                 </div>
 
-                <h3 className="text-lg font-semibold tracking-tight mb-2 group-hover:text-primary transition-colors">
-                  {post.title}
-                </h3>
+                <div className="flex flex-1 flex-col p-5">
+                  <h3 className="mb-2 text-lg font-semibold tracking-tight transition-colors group-hover:text-primary">
+                    {post.title}
+                  </h3>
 
-                <p className="text-sm text-muted-foreground line-clamp-2 mb-4">
-                  {post.description}
-                </p>
+                  <p className="mb-4 text-sm text-muted-foreground line-clamp-2">
+                    {post.description}
+                  </p>
 
-                <div className="mt-auto flex flex-wrap gap-1.5">
-                  {post.tags?.slice(0, 3).map((tag) => (
-                    <Badge
-                      key={tag}
-                      variant="secondary"
-                      className="px-2 py-0.5 text-xs font-medium"
-                    >
-                      {tag}
-                    </Badge>
-                  ))}
-                </div>
+                  <div className="mt-auto flex flex-wrap gap-1.5">
+                    {post.tags?.slice(0, 3).map((tag) => (
+                      <Badge
+                        key={tag}
+                        variant="secondary"
+                        className="border border-border/50 bg-muted/70 px-2 py-0.5 text-xs font-medium"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
 
-                <div className="mt-4 flex items-center gap-2 text-sm font-medium text-primary">
-                  Read more
-                  <ArrowUpRight className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                  <div className="mt-4 flex items-center gap-2 text-sm font-medium text-primary">
+                    Read more
+                    <ArrowUpRight className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                  </div>
                 </div>
               </Link>
             </motion.div>

--- a/src/components/home/recent-projects.tsx
+++ b/src/components/home/recent-projects.tsx
@@ -8,6 +8,7 @@ import { Section, SectionHeader } from "../ui/Section";
 import { useRef, useEffect, useState } from "react";
 import { logError } from "@/lib/logger";
 import { showContainerVariants, showItemVariants } from "@/lib/animations";
+import Image from "next/image";
 
 interface Repository {
   title: string;
@@ -18,6 +19,19 @@ interface Repository {
   stars: number;
   forks: number;
   lastUpdated: string;
+}
+
+function getInitials(title: string): string {
+  return title
+    .split(/[-\s_]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function getRepoCover(repoName: string): string {
+  return `https://opengraph.githubassets.com/1/gr8monk3ys/${repoName}`;
 }
 
 function formatTimeAgo(dateString: string): string {
@@ -89,33 +103,50 @@ export function RecentProjects() {
           variants={showContainerVariants}
           initial="hidden"
           animate={isInView ? "show" : "hidden"}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+          className="grid grid-cols-1 gap-6 md:grid-cols-6"
         >
           {loading ? (
             [...Array(3)].map((_, i) => (
               <motion.div
                 key={i}
                 variants={showItemVariants}
-                className="bg-secondary/50 rounded-xl p-4 h-[200px] animate-pulse"
+                className="h-[260px] animate-pulse rounded-2xl bg-muted/50 md:col-span-2"
               />
             ))
           ) : (
-            repositories.map((repo) => (
+            repositories.map((repo, index) => (
               <motion.div
                 key={repo.href}
                 variants={showItemVariants}
-                className="group relative bg-secondary/50 hover:bg-secondary/70 rounded-xl p-5 transition-colors"
+                className={`group relative overflow-hidden rounded-2xl border border-border/60 bg-background/95 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl ${
+                  index === 1 ? "md:col-span-4" : "md:col-span-2"
+                }`}
               >
-                <div className="space-y-3">
+                <div className="relative h-36 overflow-hidden">
+                  <Image
+                    src={getRepoCover(repo.title)}
+                    alt={`${repo.title} repository cover`}
+                    fill
+                    unoptimized
+                    className="object-cover transition-transform duration-700 group-hover:scale-105"
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+                  <div className="absolute right-4 top-4 flex size-11 items-center justify-center rounded-2xl border border-white/20 bg-gradient-to-br from-indigo-500/70 to-violet-500/70 text-sm font-semibold text-white backdrop-blur-md">
+                    {getInitials(repo.title)}
+                  </div>
+                </div>
+
+                <div className="space-y-3 p-5">
                   <div className="flex items-start justify-between gap-2">
-                    <h3 className="font-semibold truncate group-hover:text-primary transition-colors">
+                    <h3 className="truncate font-semibold transition-colors group-hover:text-primary">
                       {repo.title}
                     </h3>
                     <Link
                       href={repo.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="shrink-0 size-8 flex items-center justify-center rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                      className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors hover:bg-primary/20"
                     >
                       <ArrowUpRight className="size-4" />
                     </Link>

--- a/src/constants/products.tsx
+++ b/src/constants/products.tsx
@@ -1,13 +1,13 @@
 import { Product } from "@/types/products";
 
-import leetcodeSolver from "../../public/images/logos/leetcode-solver.webp";
-import findMyDoggo from "../../public/images/logos/find-my-doggo.webp";
-import tradingBot from "../../public/images/logos/trading-bot.webp";
-import eyebookReader from "../../public/images/logos/eyebook-reader.webp";
-import linkFlame from "../../public/images/logos/linkflame.webp";
-import TAlker from "../../public/images/logos/talker.webp";
-import blogAI from "../../public/images/logos/blog-ai.webp";
-import paperSummarizer from "../../public/images/logos/paper-summarizer.webp";
+import leetcodeSolver from "../../public/images/logos-modern/leetcode-solver.svg";
+import findMyDoggo from "../../public/images/logos-modern/find-my-doggo.svg";
+import tradingBot from "../../public/images/logos-modern/trading-bot.svg";
+import eyebookReader from "../../public/images/logos-modern/eyebook-reader.svg";
+import linkFlame from "../../public/images/logos-modern/linkflame.svg";
+import TAlker from "../../public/images/logos-modern/talker.svg";
+import blogAI from "../../public/images/logos-modern/blog-ai.svg";
+import paperSummarizer from "../../public/images/logos-modern/paper-summarizer.svg";
 
 export const products: Product[] = [
   // ============================================


### PR DESCRIPTION
### Motivation
- Remove the green-leaning gradient from the home bento cards and generated logo assets to match a more neutral/blue visual language. 
- Move cards to neutral surface tokens so the UI chrome no longer appears green-tinted.

### Description
- Updated `RecentBlogs` (`src/components/home/recent-blogs.tsx`) to use neutral surface token `bg-background/95`, added image cover layout, adjusted grid spans, and switched tag badges to `bg-muted/70` to remove green tones.
- Updated `RecentProjects` (`src/components/home/recent-projects.tsx`) to use `bg-background/95` for cards, `bg-muted/50` for loading skeletons, add repo cover images, add `getInitials`/`getRepoCover` helpers, and change the monogram badge gradient to `from-indigo-500/70 to-violet-500/70` to eliminate green accents.
- Switched `products` imports (`src/constants/products.tsx`) to use the new `public/images/logos-modern/*.svg` assets instead of the old images.
- Reworked modern logo SVGs in `public/images/logos-modern/` to replace green color stops with blue/indigo palettes (examples include replacing `#22C55E`, `#14B8A6`, `#0EA5E9` with `#3B82F6`, `#2563EB`, `#6366F1`).
- Commit message: `Remove green gradients from home cards and project logos`.

### Testing
- Ran linting with `npx eslint src/components/home/recent-blogs.tsx src/components/home/recent-projects.tsx src/constants/products.tsx`, TSX files passed linting; SVG files were ignored by ESLint configuration (warnings only).
- Ran unit tests with `npm run test` (Vitest) and all tests passed: 24 test files, 358 tests total (all passed).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Attempted a Playwright screenshot to validate visual changes but Chromium crashed with a SIGSEGV in this environment, so no end-to-end screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5627b4208320b78837d6768df779)