### PR TITLE
test(components): add tests for 12 client components, raise ratchet

### DIFF
--- a/src/__tests__/components/active-nav-link.test.tsx
+++ b/src/__tests__/components/active-nav-link.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActiveNavLink } from '@/components/ui/active-nav-link';
+
+const usePathnameMock = vi.hoisted(() => vi.fn((): string => '/'));
+
+vi.mock('next/navigation', () => ({
+  usePathname: usePathnameMock,
+}));
+
+describe('ActiveNavLink', () => {
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue('/');
+  });
+
+  it('marks the link with aria-current when the path matches exactly', () => {
+    usePathnameMock.mockReturnValue('/blog');
+    render(<ActiveNavLink href="/blog">Blog</ActiveNavLink>);
+
+    const link = screen.getByRole('link', { name: 'Blog' });
+    expect(link).toHaveAttribute('href', '/blog');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('stays active on nested paths under the href', () => {
+    usePathnameMock.mockReturnValue('/blog/some-post');
+    render(<ActiveNavLink href="/blog">Blog</ActiveNavLink>);
+
+    expect(screen.getByRole('link', { name: 'Blog' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('omits aria-current when the path does not match', () => {
+    usePathnameMock.mockReturnValue('/about');
+    render(<ActiveNavLink href="/blog">Blog</ActiveNavLink>);
+
+    expect(screen.getByRole('link', { name: 'Blog' })).not.toHaveAttribute(
+      'aria-current'
+    );
+  });
+
+  it('treats the home href as active only on the exact root path', () => {
+    usePathnameMock.mockReturnValue('/blog');
+    const { unmount } = render(<ActiveNavLink href="/">Home</ActiveNavLink>);
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute(
+      'aria-current'
+    );
+    unmount();
+
+    usePathnameMock.mockReturnValue('/');
+    render(<ActiveNavLink href="/">Home</ActiveNavLink>);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('applies activeClassName when active and inactiveClassName otherwise', () => {
+    usePathnameMock.mockReturnValue('/blog');
+    const { unmount } = render(
+      <ActiveNavLink
+        href="/blog"
+        className="base"
+        activeClassName="is-active"
+        inactiveClassName="is-inactive"
+      >
+        Blog
+      </ActiveNavLink>
+    );
+    let link = screen.getByRole('link', { name: 'Blog' });
+    expect(link).toHaveClass('base', 'is-active');
+    expect(link).not.toHaveClass('is-inactive');
+    unmount();
+
+    usePathnameMock.mockReturnValue('/about');
+    render(
+      <ActiveNavLink
+        href="/blog"
+        className="base"
+        activeClassName="is-active"
+        inactiveClassName="is-inactive"
+      >
+        Blog
+      </ActiveNavLink>
+    );
+    link = screen.getByRole('link', { name: 'Blog' });
+    expect(link).toHaveClass('base', 'is-inactive');
+    expect(link).not.toHaveClass('is-active');
+  });
+});

--- a/src/__tests__/components/breadcrumb-nav.test.tsx
+++ b/src/__tests__/components/breadcrumb-nav.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BreadcrumbNav } from '@/components/ui/breadcrumb-nav';
+
+const usePathnameMock = vi.hoisted(() => vi.fn((): string => '/'));
+
+vi.mock('next/navigation', () => ({
+  usePathname: usePathnameMock,
+}));
+
+describe('BreadcrumbNav', () => {
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue('/');
+  });
+
+  it('renders nothing on the home page', () => {
+    const { container } = render(<BreadcrumbNav />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a breadcrumb trail derived from the pathname', () => {
+    usePathnameMock.mockReturnValue('/blog/some-post');
+    render(<BreadcrumbNav />);
+
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'href',
+      '/'
+    );
+    expect(screen.getByRole('link', { name: 'Blog' })).toHaveAttribute(
+      'href',
+      '/blog'
+    );
+  });
+
+  it('marks the last segment as the current page, not a link', () => {
+    usePathnameMock.mockReturnValue('/blog/some-post');
+    render(<BreadcrumbNav />);
+
+    const current = screen.getByText('Some post');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(screen.queryByRole('link', { name: 'Some post' })).toBeNull();
+  });
+
+  it('uses custom segment labels when provided', () => {
+    usePathnameMock.mockReturnValue('/blog/some-post');
+    render(<BreadcrumbNav customSegments={{ 'some-post': 'my custom title' }} />);
+
+    expect(screen.getByText('My custom title')).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('supports a custom home label', () => {
+    usePathnameMock.mockReturnValue('/blog');
+    render(<BreadcrumbNav homeLabel="Start" />);
+
+    expect(screen.getByRole('link', { name: 'Start' })).toHaveAttribute(
+      'href',
+      '/'
+    );
+  });
+
+  it('omits the home crumb when excludeHome is set', () => {
+    usePathnameMock.mockReturnValue('/blog/some-post');
+    render(<BreadcrumbNav excludeHome />);
+
+    expect(screen.queryByRole('link', { name: 'Home' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Blog' })).toHaveAttribute(
+      'href',
+      '/blog'
+    );
+  });
+});

--- a/src/__tests__/components/code-block.test.tsx
+++ b/src/__tests__/components/code-block.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { CodeBlock } from "@/components/blog/code-block";
+
+const writeText = vi.fn();
+
+describe("CodeBlock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the code content", () => {
+    render(
+      <CodeBlock className="language-typescript">
+        <code>const x = 1;</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByText("const x = 1;")).toBeInTheDocument();
+  });
+
+  it("shows the mapped language label from the className", () => {
+    render(
+      <CodeBlock className="language-tsx">
+        <code>{"<App />"}</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByText("TypeScript (React)")).toBeInTheDocument();
+  });
+
+  it("falls back to an uppercase label for unknown languages", () => {
+    render(
+      <CodeBlock className="language-brainfuck">
+        <code>+++</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByText("BRAINFUCK")).toBeInTheDocument();
+  });
+
+  it("labels blocks without a language class as plain text", () => {
+    render(
+      <CodeBlock>
+        <code>just words</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByText("Plain Text")).toBeInTheDocument();
+  });
+
+  it("prefers the filename over the language label when provided", () => {
+    render(
+      <CodeBlock className="language-typescript" filename="example.ts">
+        <code>const x = 1;</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByText("example.ts")).toBeInTheDocument();
+    expect(screen.queryByText("TypeScript")).not.toBeInTheDocument();
+  });
+
+  it("shows a singular or plural line count", () => {
+    const { unmount } = render(
+      <CodeBlock className="language-js">
+        <code>single();</code>
+      </CodeBlock>
+    );
+    expect(screen.getByText("1 line")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <CodeBlock className="language-js">
+        <code>{"a();\nb();\nc();"}</code>
+      </CodeBlock>
+    );
+    expect(screen.getByText("3 lines")).toBeInTheDocument();
+  });
+
+  it("copies the code text and reverts the button label after the timeout", async () => {
+    vi.useFakeTimers();
+    render(
+      <CodeBlock className="language-js">
+        <code>{"const answer = 42;"}</code>
+      </CodeBlock>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy code to clipboard" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith("const answer = 42;");
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+  });
+
+  it("falls back to execCommand when the clipboard API fails", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      writable: true,
+      value: execCommand,
+    });
+
+    render(
+      <CodeBlock className="language-js">
+        <code>{"fallback();"}</code>
+      </CodeBlock>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy code to clipboard" }));
+    });
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+  });
+
+  it("collapses long code blocks and toggles with the expand button", () => {
+    const longCode = Array.from({ length: 25 }, (_, i) => `line${i + 1}();`).join("\n");
+    render(
+      <CodeBlock className="language-js">
+        <code>{longCode}</code>
+      </CodeBlock>
+    );
+
+    const toggle = screen.getByRole("button", { name: /Show 5 more lines/ });
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /Show less/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show less/ }));
+    expect(screen.getByRole("button", { name: /Show 5 more lines/ })).toBeInTheDocument();
+  });
+
+  it("does not show an expand button for short code", () => {
+    render(
+      <CodeBlock className="language-js">
+        <code>{"short();"}</code>
+      </CodeBlock>
+    );
+
+    expect(screen.queryByRole("button", { name: /more lines/ })).not.toBeInTheDocument();
+  });
+
+  it("toggles line numbers via the header button", () => {
+    render(
+      <CodeBlock className="language-js">
+        <code>{"a();\nb();\nc();"}</code>
+      </CodeBlock>
+    );
+
+    // Line numbers are on by default.
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", { name: "Hide line numbers" });
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("button", { name: "Show line numbers" })).toBeInTheDocument();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+  });
+
+  it("respects showLineNumbers={false}", () => {
+    render(
+      <CodeBlock className="language-js" showLineNumbers={false}>
+        <code>{"a();\nb();"}</code>
+      </CodeBlock>
+    );
+
+    expect(screen.getByRole("button", { name: "Show line numbers" })).toBeInTheDocument();
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/contact-form.test.tsx
+++ b/src/__tests__/components/contact-form.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { ContactForm } from "@/components/contact/ContactForm";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+function fillForm() {
+  fireEvent.change(screen.getByLabelText("Name"), {
+    target: { value: "Ada Lovelace" },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "ada@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Subject"), {
+    target: { value: "RAG audit" },
+  });
+  fireEvent.change(screen.getByLabelText("Message"), {
+    target: { value: "We need retrieval evaluated before launch." },
+  });
+}
+
+function submitForm() {
+  const button = screen.getByRole("button", { name: /send project details/i });
+  const form = button.closest("form");
+  expect(form).not.toBeNull();
+  fireEvent.submit(form as HTMLFormElement);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("ContactForm", () => {
+  it("renders the expected fields and submit button", () => {
+    render(<ContactForm />);
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Subject")).toBeInTheDocument();
+    expect(screen.getByLabelText("Message")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send project details/i })
+    ).toBeInTheDocument();
+  });
+
+  it("marks every field required for client-side validation", () => {
+    render(<ContactForm />);
+    expect(screen.getByLabelText("Name")).toBeRequired();
+    expect(screen.getByLabelText("Email")).toBeRequired();
+    expect(screen.getByLabelText("Subject")).toBeRequired();
+    expect(screen.getByLabelText("Message")).toBeRequired();
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+  });
+
+  it("posts the form data to /api/contact and shows the success message", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    render(<ContactForm />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText(/message sent/i)).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/contact");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      subject: "RAG audit",
+      message: "We need retrieval evaluated before launch.",
+    });
+  });
+
+  it("clears the fields after a successful submit", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    render(<ContactForm />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText(/message sent/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText("Email")).toHaveValue("");
+    expect(screen.getByLabelText("Subject")).toHaveValue("");
+    expect(screen.getByLabelText("Message")).toHaveValue("");
+  });
+
+  it("shows the error message when the server responds with a failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false));
+    render(<ContactForm />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText(/message failed to send/i)).toBeInTheDocument();
+    });
+    // Fields are not cleared on failure.
+    expect(screen.getByLabelText("Name")).toHaveValue("Ada Lovelace");
+  });
+
+  it("shows the error message when the request throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    render(<ContactForm />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText(/message failed to send/i)).toBeInTheDocument();
+    });
+  });
+
+  it("disables the button and shows Sending... while the request is in flight", async () => {
+    let resolveFetch!: (value: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    render(<ContactForm />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /sending/i })).toBeDisabled();
+    });
+
+    act(() => resolveFetch(jsonResponse({})));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /send project details/i })
+      ).toBeEnabled();
+    });
+  });
+});

--- a/src/__tests__/components/fallback-image.test.tsx
+++ b/src/__tests__/components/fallback-image.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FallbackImage } from '@/components/ui/fallback-image';
+
+// next/image is mocked globally in setup.tsx and renders a plain <img>.
+
+describe('FallbackImage', () => {
+  it('renders the provided source', () => {
+    render(
+      <FallbackImage
+        src="/images/blog/real.webp"
+        alt="A real picture"
+        width={100}
+        height={100}
+        enableBlur={false}
+      />
+    );
+    expect(screen.getByRole('img', { name: 'A real picture' })).toHaveAttribute(
+      'src',
+      '/images/blog/real.webp'
+    );
+  });
+
+  it('swaps to the default fallback when the image errors', () => {
+    render(
+      <FallbackImage
+        src="/images/blog/missing.webp"
+        alt="A missing picture"
+        width={100}
+        height={100}
+        enableBlur={false}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'A missing picture' });
+    fireEvent.error(img);
+    expect(img).toHaveAttribute('src', '/images/blog/default.webp');
+  });
+
+  it('swaps to a custom fallbackSrc when provided', () => {
+    render(
+      <FallbackImage
+        src="/images/blog/missing.webp"
+        fallbackSrc="/images/custom-fallback.webp"
+        alt="A missing picture"
+        width={100}
+        height={100}
+        enableBlur={false}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'A missing picture' });
+    fireEvent.error(img);
+    expect(img).toHaveAttribute('src', '/images/custom-fallback.webp');
+  });
+
+  it('invokes onError only once for the same failing source', () => {
+    const onError = vi.fn();
+    render(
+      <FallbackImage
+        src="/images/blog/missing.webp"
+        alt="A missing picture"
+        width={100}
+        height={100}
+        enableBlur={false}
+        onError={onError}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'A missing picture' });
+    fireEvent.error(img);
+    fireEvent.error(img);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/components/newsletter-form.test.tsx
+++ b/src/__tests__/components/newsletter-form.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { NewsletterForm } from "@/components/newsletter/newsletter-form";
+import { NEWSLETTER_TOPICS } from "@/constants/newsletter";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+function fillEmail(value = "reader@example.com") {
+  fireEvent.change(screen.getByLabelText("Email address"), {
+    target: { value },
+  });
+}
+
+function submitForm() {
+  const button = screen.getByRole("button", { name: /subscribe/i });
+  const form = button.closest("form");
+  expect(form).not.toBeNull();
+  fireEvent.submit(form as HTMLFormElement);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("NewsletterForm", () => {
+  it("renders the email input, subscribe button, and all topic toggles", () => {
+    render(<NewsletterForm />);
+    expect(screen.getByLabelText("Email address")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Subscribe" })).toBeInTheDocument();
+    for (const topic of NEWSLETTER_TOPICS) {
+      expect(screen.getByRole("button", { name: topic.label })).toBeInTheDocument();
+    }
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+  });
+
+  it("requires the email field for client-side validation", () => {
+    render(<NewsletterForm />);
+    const input = screen.getByLabelText("Email address");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("type", "email");
+  });
+
+  it("toggles a topic on and off and updates the counter", () => {
+    render(<NewsletterForm />);
+    const topic = screen.getByRole("button", { name: "RAG + LLM Systems" });
+    expect(topic).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(topic);
+    expect(topic).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("1/6")).toBeInTheDocument();
+
+    fireEvent.click(topic);
+    expect(topic).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+  });
+
+  it("pre-selects valid defaultTopics and drops unknown ones", () => {
+    render(<NewsletterForm defaultTopics={["rag-llms", "not-a-topic", "ai-society"]} />);
+    expect(
+      screen.getByRole("button", { name: "RAG + LLM Systems" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "AI + Society" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("2/6")).toBeInTheDocument();
+  });
+
+  it("posts email, topics, and source to the subscribe endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: "Welcome aboard!" }));
+    render(<NewsletterForm sourcePath="/blog/some-post" />);
+
+    fillEmail();
+    fireEvent.click(screen.getByRole("button", { name: "Systems + Craft" }));
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome aboard!")).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/newsletter/subscribe");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      email: "reader@example.com",
+      topics: ["systems-craft"],
+      source: "/blog/some-post",
+    });
+  });
+
+  it("shows success state, clears the email, and disables controls after subscribing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: "Successfully subscribed!" }));
+    render(<NewsletterForm />);
+
+    fillEmail();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /subscribed!/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText("Successfully subscribed!")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email address")).toHaveValue("");
+    expect(screen.getByLabelText("Email address")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /subscribed!/i })).toBeDisabled();
+  });
+
+  it("shows the server error message when the response is not ok", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "Email already subscribed" }, false));
+    render(<NewsletterForm />);
+
+    fillEmail();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Email already subscribed")).toBeInTheDocument();
+    });
+    // The email is kept so the visitor can retry.
+    expect(screen.getByLabelText("Email address")).toHaveValue("reader@example.com");
+    expect(screen.getByRole("button", { name: "Subscribe" })).toBeEnabled();
+  });
+
+  it("shows a network error message when the request throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    render(<NewsletterForm />);
+
+    fillEmail();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Subscribing... and disables the form while the request is in flight", async () => {
+    let resolveFetch!: (value: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    render(<NewsletterForm />);
+
+    fillEmail();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /subscribing/i })).toBeDisabled();
+    });
+    expect(screen.getByLabelText("Email address")).toBeDisabled();
+
+    act(() => resolveFetch(jsonResponse({ message: "Done" })));
+
+    await waitFor(() => {
+      expect(screen.getByText("Done")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/scroll-to-top.test.tsx
+++ b/src/__tests__/components/scroll-to-top.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScrollToTop } from '@/components/ui/scroll-to-top';
+
+function setScrollOffset(value: number) {
+  Object.defineProperty(window, 'pageYOffset', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+describe('ScrollToTop', () => {
+  let scrollToMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollToMock = vi.fn();
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      writable: true,
+      value: scrollToMock,
+    });
+    setScrollOffset(0);
+  });
+
+  afterEach(() => {
+    setScrollOffset(0);
+  });
+
+  it('is hidden before the page is scrolled', () => {
+    render(<ScrollToTop />);
+    expect(screen.queryByRole('button', { name: 'Scroll to top' })).toBeNull();
+  });
+
+  it('appears after scrolling past the 300px threshold', () => {
+    render(<ScrollToTop />);
+    setScrollOffset(400);
+    fireEvent.scroll(window);
+    expect(
+      screen.getByRole('button', { name: 'Scroll to top' })
+    ).toBeInTheDocument();
+  });
+
+  it('stays hidden at or below the threshold', () => {
+    render(<ScrollToTop />);
+    setScrollOffset(300);
+    fireEvent.scroll(window);
+    expect(screen.queryByRole('button', { name: 'Scroll to top' })).toBeNull();
+  });
+
+  it('hides again when scrolled back to the top', () => {
+    render(<ScrollToTop />);
+    setScrollOffset(400);
+    fireEvent.scroll(window);
+    expect(
+      screen.getByRole('button', { name: 'Scroll to top' })
+    ).toBeInTheDocument();
+
+    setScrollOffset(0);
+    fireEvent.scroll(window);
+    expect(screen.queryByRole('button', { name: 'Scroll to top' })).toBeNull();
+  });
+
+  it('scrolls smoothly to the top when clicked', () => {
+    render(<ScrollToTop />);
+    setScrollOffset(400);
+    fireEvent.scroll(window);
+    fireEvent.click(screen.getByRole('button', { name: 'Scroll to top' }));
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+});

--- a/src/__tests__/components/series-navigation.test.tsx
+++ b/src/__tests__/components/series-navigation.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import { SeriesNavigation } from "@/components/blog/series-navigation";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const posts = [
+  { slug: "part-one", title: "Getting Started", seriesOrder: 1 },
+  { slug: "part-two", title: "Going Deeper", seriesOrder: 2 },
+  { slug: "part-three", title: "Wrapping Up", seriesOrder: 3 },
+];
+
+function renderWithSWR(ui: ReactNode) {
+  return render(
+    <SWRConfig
+      value={{ provider: () => new Map(), dedupingInterval: 0, errorRetryCount: 0 }}
+    >
+      {ui}
+    </SWRConfig>
+  );
+}
+
+function mockSeriesResponse(seriesPosts: typeof posts) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ posts: seriesPosts }),
+  });
+}
+
+function prevLink() {
+  return screen.getByText("Previous").closest("a");
+}
+
+function nextLink() {
+  return screen.getByText("Next").closest("a");
+}
+
+describe("SeriesNavigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a loading skeleton while the series is being fetched", () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-two" currentOrder={2} />
+    );
+
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+  });
+
+  it("requests the series endpoint with the encoded series name", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="AI & ML" currentSlug="part-one" currentOrder={1} />
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/series?name=${encodeURIComponent("AI & ML")}`,
+        undefined
+      );
+    });
+  });
+
+  it("renders the series title, position, and the full ordered post list", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-two" currentOrder={2} />
+    );
+
+    expect(await screen.findByText("Deep Learning Series")).toBeInTheDocument();
+    expect(screen.getByText("Part 2 of 3")).toBeInTheDocument();
+
+    // Order markers come from seriesOrder, rendered as an ordered list.
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveTextContent("1.");
+    expect(items[0]).toHaveTextContent("Getting Started");
+    expect(items[1]).toHaveTextContent("2.");
+    expect(items[2]).toHaveTextContent("3.");
+    expect(items[2]).toHaveTextContent("Wrapping Up");
+  });
+
+  it("marks the current post as current text instead of a link", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-two" currentOrder={2} />
+    );
+
+    const current = await screen.findByText("Going Deeper (current)");
+    expect(current.closest("a")).toBeNull();
+
+    expect(screen.getByRole("link", { name: "Getting Started" })).toHaveAttribute(
+      "href",
+      "/blog/part-one"
+    );
+  });
+
+  it("links to both neighbors from a middle post", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-two" currentOrder={2} />
+    );
+
+    await screen.findByText("Deep Learning Series");
+    expect(prevLink()).toHaveAttribute("href", "/blog/part-one");
+    expect(nextLink()).toHaveAttribute("href", "/blog/part-three");
+  });
+
+  it("omits the previous link on the first post in the series", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-one" currentOrder={1} />
+    );
+
+    await screen.findByText("Deep Learning Series");
+    expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+    expect(nextLink()).toHaveAttribute("href", "/blog/part-two");
+  });
+
+  it("omits the next link on the last post in the series", async () => {
+    mockSeriesResponse(posts);
+
+    renderWithSWR(
+      <SeriesNavigation seriesName="Deep Learning" currentSlug="part-three" currentOrder={3} />
+    );
+
+    await screen.findByText("Deep Learning Series");
+    expect(screen.queryByText("Next")).not.toBeInTheDocument();
+    expect(prevLink()).toHaveAttribute("href", "/blog/part-two");
+  });
+
+  it("renders nothing when the series has no posts", async () => {
+    mockSeriesResponse([]);
+
+    const { container } = renderWithSWR(
+      <SeriesNavigation seriesName="Empty" currentSlug="part-one" currentOrder={1} />
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it("renders nothing when the API omits the posts array", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    const { container } = renderWithSWR(
+      <SeriesNavigation seriesName="Broken" currentSlug="part-one" currentOrder={1} />
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/__tests__/components/social-share.test.tsx
+++ b/src/__tests__/components/social-share.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { SocialShare } from "@/components/blog/social-share";
+import { logError } from "@/lib/logger";
+
+vi.mock("@/lib/logger", () => ({
+  logError: vi.fn(),
+}));
+
+const props = {
+  title: "Nihilism Is Lazy Philosophy",
+  description: "Nothing matters is the intellectual equivalent of not voting.",
+  url: "https://lscaturchio.xyz/blog/nihilism-is-lazy",
+};
+
+const writeText = vi.fn();
+let openSpy: ReturnType<typeof vi.spyOn>;
+
+describe("SocialShare", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+    Reflect.deleteProperty(navigator, "share");
+    vi.useRealTimers();
+  });
+
+  it("opens the Twitter intent URL with encoded title and url", () => {
+    render(<SocialShare {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share on Twitter" }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+        props.title
+      )}&url=${encodeURIComponent(props.url)}`,
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens the LinkedIn share URL with the encoded url", () => {
+    render(<SocialShare {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share on LinkedIn" }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(props.url)}`,
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens the Bluesky compose URL with title and url in the text", () => {
+    render(<SocialShare {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share on Bluesky" }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://bsky.app/intent/compose?text=${encodeURIComponent(
+        `${props.title}\n${props.url}`
+      )}`,
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens the Hacker News submit URL with encoded url and title", () => {
+    render(<SocialShare {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share on Hacker News" }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://news.ycombinator.com/submitlink?u=${encodeURIComponent(
+        props.url
+      )}&t=${encodeURIComponent(props.title)}`,
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("copies the share URL and shows Copied! until the timeout elapses", async () => {
+    vi.useFakeTimers();
+    render(<SocialShare {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(props.url);
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy Link")).toBeInTheDocument();
+  });
+
+  it("logs the error and keeps the default label when clipboard write fails", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    render(<SocialShare {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
+    });
+
+    expect(logError).toHaveBeenCalledWith(
+      "Failed to copy link",
+      expect.any(Error),
+      { component: "SocialShare" }
+    );
+    expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy Link")).toBeInTheDocument();
+  });
+
+  it("hides the native share button when navigator.share is unavailable", () => {
+    render(<SocialShare {...props} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Share via native share" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the native share button and shares title, text, and url", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: share,
+    });
+
+    render(<SocialShare {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share via native share" }));
+    });
+
+    expect(share).toHaveBeenCalledWith({
+      title: props.title,
+      text: props.description,
+      url: props.url,
+    });
+  });
+});

--- a/src/__tests__/components/theme-toggle.test.tsx
+++ b/src/__tests__/components/theme-toggle.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
+
+const themeMocks = vi.hoisted(() => ({
+  theme: 'light',
+  setTheme: vi.fn(),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: themeMocks.theme, setTheme: themeMocks.setTheme }),
+}));
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    themeMocks.theme = 'light';
+    themeMocks.setTheme.mockClear();
+  });
+
+  it('renders a button with an accessible name once mounted', () => {
+    render(<ThemeToggle />);
+    expect(
+      screen.getByRole('button', { name: 'Toggle theme' })
+    ).toBeInTheDocument();
+  });
+
+  it('switches to dark when the current theme is light', () => {
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+    expect(themeMocks.setTheme).toHaveBeenCalledTimes(1);
+    expect(themeMocks.setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('switches to light when the current theme is dark', () => {
+    themeMocks.theme = 'dark';
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+    expect(themeMocks.setTheme).toHaveBeenCalledTimes(1);
+    expect(themeMocks.setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('cycles back and forth across clicks', () => {
+    const { unmount } = render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+    expect(themeMocks.setTheme).toHaveBeenLastCalledWith('dark');
+    unmount();
+
+    themeMocks.theme = 'dark';
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+    expect(themeMocks.setTheme).toHaveBeenLastCalledWith('light');
+  });
+});

--- a/src/__tests__/components/unsubscribe-page-client.test.tsx
+++ b/src/__tests__/components/unsubscribe-page-client.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UnsubscribePageClient } from "@/components/pages/unsubscribe-page-client";
+
+describe("UnsubscribePageClient", () => {
+  it("renders the success state with message and both navigation links", () => {
+    render(
+      <UnsubscribePageClient status="success" message="You have been unsubscribed." />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Unsubscribed Successfully" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("You have been unsubscribed.")).toBeInTheDocument();
+    expect(screen.getByText(/removed from my newsletter/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to Home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(screen.getByRole("link", { name: "Browse Blog" })).toHaveAttribute(
+      "href",
+      "/blog"
+    );
+  });
+
+  it("renders the error state without the blog link", () => {
+    render(
+      <UnsubscribePageClient status="error" message="Something went wrong." />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Unsubscribe Failed" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to Home" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Browse Blog" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/removed from my newsletter/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the no-token state as an invalid link", () => {
+    render(
+      <UnsubscribePageClient status="no-token" message="This link is missing a token." />
+    );
+
+    expect(screen.getByRole("heading", { name: "Invalid Link" })).toBeInTheDocument();
+    expect(screen.getByText("This link is missing a token.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to Home" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Browse Blog" })).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/view-counter.test.tsx
+++ b/src/__tests__/components/view-counter.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import { ViewCounter } from "@/components/blog/view-counter";
+
+vi.mock("@/lib/logger", () => ({
+  logError: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function renderWithSWR(ui: ReactNode) {
+  return render(
+    <SWRConfig
+      value={{ provider: () => new Map(), dedupingInterval: 0, errorRetryCount: 0 }}
+    >
+      {ui}
+    </SWRConfig>
+  );
+}
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function postCalls() {
+  return mockFetch.mock.calls.filter(
+    ([, init]) => (init as RequestInit | undefined)?.method === "POST"
+  );
+}
+
+describe("ViewCounter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("fetches the view count and renders it", async () => {
+    mockFetch.mockImplementation(async () => jsonResponse({ views: 42 }));
+
+    renderWithSWR(<ViewCounter slug="my-post" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("42 views")).toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenCalledWith("/api/views?slug=my-post", undefined);
+  });
+
+  it("posts a view on first visit and marks the session as viewed", async () => {
+    mockFetch.mockImplementation(async () => jsonResponse({ views: 8 }));
+
+    renderWithSWR(<ViewCounter slug="fresh-post" />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/views",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ slug: "fresh-post" }),
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(sessionStorage.getItem("viewed_fresh-post")).toBe("true");
+    });
+  });
+
+  it("does not post again when the post was already viewed this session", async () => {
+    sessionStorage.setItem("viewed_seen-post", "true");
+    mockFetch.mockImplementation(async () => jsonResponse({ views: 100 }));
+
+    renderWithSWR(<ViewCounter slug="seen-post" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("100 views")).toBeInTheDocument();
+    });
+    expect(postCalls()).toHaveLength(0);
+  });
+
+  it("uses the singular label for exactly one view", async () => {
+    sessionStorage.setItem("viewed_single-post", "true");
+    mockFetch.mockImplementation(async () => jsonResponse({ views: 1 }));
+
+    renderWithSWR(<ViewCounter slug="single-post" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("1 view")).toBeInTheDocument();
+    });
+  });
+
+  it("renders a placeholder while the count is still loading", () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    renderWithSWR(<ViewCounter slug="slow-post" />);
+
+    expect(screen.getByText("---")).toBeInTheDocument();
+  });
+
+  it("degrades gracefully to the placeholder when fetching fails", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    renderWithSWR(<ViewCounter slug="broken-post" />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/views?slug=broken-post", undefined);
+    });
+    expect(screen.getByText("---")).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,12 +18,12 @@ export default defineConfig({
         '.next/',
       ],
       // Ratchet: set just below actual coverage so CI fails on regressions.
-      // Raise these as coverage improves (actual on 2026-07-06: 69.96/60.88/62.6/71.4).
+      // Raise these as coverage improves (actual on 2026-07-08: 75.07/67.09/70.56/76.33).
       thresholds: {
-        statements: 69,
-        branches: 60,
-        functions: 62,
-        lines: 71,
+        statements: 74,
+        branches: 66,
+        functions: 69,
+        lines: 75,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Add unit tests for 12 previously untested client components: active-nav-link, breadcrumb-nav, code-block, contact-form, fallback-image, newsletter-form, scroll-to-top, series-navigation, social-share, theme-toggle, unsubscribe-page-client, and view-counter
- Raise coverage ratchet thresholds in `vitest.config.ts` to just below the new actuals (75.07/67.09/70.56/76.33 → statements 74, branches 66, functions 69, lines 75)

## Test plan
- [x] `bun run test` — 611 tests across 67 files, all passing
- [x] `bun run test:coverage` — passes with raised thresholds
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)