### PR TITLE
test(lib): cover chat providers, chat context, letterboxd CSV, ollama

### DIFF
--- a/src/__tests__/lib/chat-context-load.test.ts
+++ b/src/__tests__/lib/chat-context-load.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { loadBlogContext, buildSystemPromptWithContext } from '@/lib/chat/context';
+
+vi.mock('fs/promises', () => ({
+  default: { access: vi.fn(), readFile: vi.fn() },
+}));
+
+const mockAccess = vi.mocked(fs.access);
+const mockReadFile = vi.mocked(fs.readFile);
+
+const MDX = `import { Sidenote } from "@/components/sidenote";
+
+export const meta = {
+  title: "Digital Gardens",
+  description: "Notes on tending a garden of notes.",
+  date: "2026-01-01",
+  image: "/blog/gardens.webp",
+  tags: ["writing"],
+};
+
+## Why gardens
+
+Because [streams](/blog/streams) wash away.
+
+### Tending
+
+Prune often.
+
+# A top-level heading that should be ignored
+`;
+
+/** Only the given relative path (under src/app/blog) exists. */
+function onlyFileExists(relPath: string, content: string) {
+  const target = path.join(process.cwd(), 'src', 'app', 'blog', relPath);
+  mockAccess.mockImplementation((p) =>
+    String(p) === target ? Promise.resolve() : Promise.reject(new Error('ENOENT')),
+  );
+  mockReadFile.mockResolvedValue(content);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loadBlogContext', () => {
+  it('returns null when no MDX file exists for the slug', async () => {
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    expect(await loadBlogContext('missing-post')).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('loads <slug>/content.mdx and extracts meta, headings, and text', async () => {
+    onlyFileExists(path.join('digital-gardens', 'content.mdx'), MDX);
+
+    const ctx = await loadBlogContext('digital-gardens');
+
+    expect(ctx).not.toBeNull();
+    expect(ctx!.title).toBe('Digital Gardens');
+    expect(ctx!.description).toBe('Notes on tending a garden of notes.');
+    // Only ##/### headings count, markdown links are flattened to their text.
+    expect(ctx!.headings).toEqual(['Why gardens', 'Tending']);
+    expect(ctx!.text).toContain('Prune often.');
+  });
+
+  it('falls back to the flat <slug>.mdx layout', async () => {
+    onlyFileExists('digital-gardens.mdx', MDX);
+
+    const ctx = await loadBlogContext('digital-gardens');
+
+    expect(ctx?.title).toBe('Digital Gardens');
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips import lines and the meta export from the context text', async () => {
+    onlyFileExists('digital-gardens.mdx', MDX);
+
+    const ctx = await loadBlogContext('digital-gardens');
+
+    expect(ctx!.text).not.toContain('import {');
+    expect(ctx!.text).not.toContain('export const meta');
+    expect(ctx!.text).toContain('Because [streams](/blog/streams) wash away.');
+  });
+
+  it('truncates oversized posts and marks the cut', async () => {
+    const huge = `## Only Heading\n\n${'x'.repeat(9000)}`;
+    onlyFileExists('big-post.mdx', huge);
+
+    const ctx = await loadBlogContext('big-post');
+
+    expect(ctx!.text.endsWith('[truncated]')).toBe(true);
+    expect(ctx!.text.length).toBeLessThan(huge.length);
+  });
+});
+
+describe('buildSystemPromptWithContext with a post context', () => {
+  const RETRIEVAL = { context: 'matched text', confidence: 'strong' as const, closest: [] };
+
+  it('renders title, description, sections, and content', () => {
+    const out = buildSystemPromptWithContext('Base.', {
+      title: 'Digital Gardens',
+      description: 'Notes on tending.',
+      headings: ['Why gardens', 'Tending'],
+      text: 'Body text.',
+    }, RETRIEVAL);
+
+    expect(out).toContain('Blog post context:');
+    expect(out).toContain('Title: Digital Gardens');
+    expect(out).toContain('Description: Notes on tending.');
+    expect(out).toContain('Sections:\n- Why gardens\n- Tending');
+    expect(out).toContain('Post content:\nBody text.');
+  });
+
+  it('omits the sections list when the post has no headings', () => {
+    const out = buildSystemPromptWithContext('Base.', {
+      headings: [],
+      text: 'Body text.',
+    }, RETRIEVAL);
+
+    expect(out).toContain('Blog post context:');
+    expect(out).not.toContain('Sections:');
+  });
+});

--- a/src/__tests__/lib/chat-providers.test.ts
+++ b/src/__tests__/lib/chat-providers.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the OpenAI SDK before importing the module under test. The providers
+// module reads its env flags at import time, so every test re-imports it via
+// vi.resetModules() + dynamic import (same pattern as openai.test.ts).
+const mockCreate = vi.fn();
+const MockOpenAI = vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+  this.chat = { completions: { create: mockCreate } };
+  return this;
+});
+
+vi.mock('openai', () => ({ default: MockOpenAI }));
+
+const mockIsOllamaAvailable = vi.fn();
+const mockOllamaChat = vi.fn();
+vi.mock('@/lib/ollama', () => ({
+  isOllamaAvailable: (...args: unknown[]) => mockIsOllamaAvailable(...args),
+  createOllamaChatCompletion: (...args: unknown[]) => mockOllamaChat(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+function completionWith(content: string | null) {
+  return { choices: [{ message: { content } }] };
+}
+
+async function importProviders() {
+  return import('@/lib/chat/providers');
+}
+
+describe('generateChatAnswer', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENAI_CHAT_MODEL;
+    delete process.env.OPENAI_FALLBACK_CHAT_MODEL;
+    delete process.env.OPENROUTER_CHAT_MODEL;
+    delete process.env.OPENROUTER_FALLBACK_CHAT_MODEL;
+    delete process.env.OLLAMA_CHAT_MODEL;
+    mockIsOllamaAvailable.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when no provider is configured and Ollama is down', async () => {
+    const { generateChatAnswer } = await importProviders();
+    expect(await generateChatAnswer('sys', 'q')).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  describe('OpenAI', () => {
+    beforeEach(() => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+    });
+
+    it('answers with the primary model on success', async () => {
+      mockCreate.mockResolvedValue(completionWith('an answer'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toEqual({
+        answer: 'an answer',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        usedFallbackModel: false,
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4o-mini',
+          messages: [
+            { role: 'system', content: 'sys' },
+            { role: 'user', content: 'q' },
+          ],
+        }),
+      );
+      expect(mockIsOllamaAvailable).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the secondary model when the primary fails', async () => {
+      mockCreate
+        .mockRejectedValueOnce(new Error('model overloaded'))
+        .mockResolvedValueOnce(completionWith('fallback answer'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({
+        answer: 'fallback answer',
+        provider: 'openai',
+        model: 'gpt-4.1-nano',
+        usedFallbackModel: true,
+      });
+    });
+
+    it('tries the fallback model when the primary returns empty content', async () => {
+      mockCreate
+        .mockResolvedValueOnce(completionWith(null))
+        .mockResolvedValueOnce(completionWith('fallback answer'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({ model: 'gpt-4.1-nano', usedFallbackModel: true });
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('moves on to Ollama when every OpenAI model fails', async () => {
+      mockCreate.mockRejectedValue(new Error('model overloaded'));
+      mockIsOllamaAvailable.mockResolvedValue(true);
+      mockOllamaChat.mockResolvedValue('local answer');
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({ provider: 'ollama', answer: 'local answer' });
+      expect(mockCreate).toHaveBeenCalledTimes(2); // primary + fallback model
+    });
+
+    it('disables OpenAI for the process after an auth error', async () => {
+      mockCreate.mockRejectedValue(Object.assign(new Error('bad key'), { status: 401 }));
+      mockIsOllamaAvailable.mockResolvedValue(true);
+      mockOllamaChat.mockResolvedValue('local answer');
+      const { generateChatAnswer } = await importProviders();
+
+      expect(await generateChatAnswer('sys', 'q')).toMatchObject({ provider: 'ollama' });
+      expect(mockCreate).toHaveBeenCalledTimes(1); // no fallback-model retry on auth errors
+
+      expect(await generateChatAnswer('sys', 'again')).toMatchObject({ provider: 'ollama' });
+      expect(mockCreate).toHaveBeenCalledTimes(1); // never asked again
+    });
+
+    it('respects model overrides from the environment', async () => {
+      process.env.OPENAI_CHAT_MODEL = 'gpt-custom';
+      mockCreate.mockResolvedValue(completionWith('ok'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({ model: 'gpt-custom' });
+    });
+  });
+
+  describe('OpenRouter', () => {
+    beforeEach(() => {
+      process.env.OPENROUTER_API_KEY = 'or-test';
+    });
+
+    it('answers via OpenRouter when OpenAI is not configured', async () => {
+      mockCreate.mockResolvedValue(completionWith('routed answer'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toEqual({
+        answer: 'routed answer',
+        provider: 'openrouter',
+        model: 'openai/gpt-4.1-nano',
+        usedFallbackModel: false,
+      });
+    });
+
+    it('builds the client with the OpenRouter base URL and attribution headers', async () => {
+      mockCreate.mockResolvedValue(completionWith('ok'));
+      const { generateChatAnswer } = await importProviders();
+
+      await generateChatAnswer('sys', 'q');
+
+      expect(MockOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'or-test',
+          baseURL: 'https://openrouter.ai/api/v1',
+          defaultHeaders: expect.objectContaining({
+            'HTTP-Referer': expect.any(String),
+            'X-Title': expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    it('is used when OpenAI is configured but fails', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      mockCreate
+        .mockRejectedValueOnce(Object.assign(new Error('unauthorized'), { status: 401 }))
+        .mockResolvedValueOnce(completionWith('routed answer'));
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({ provider: 'openrouter', answer: 'routed answer' });
+    });
+
+    it('falls through to Ollama when OpenRouter fails', async () => {
+      mockCreate.mockRejectedValue(new Error('502 bad gateway'));
+      mockIsOllamaAvailable.mockResolvedValue(true);
+      mockOllamaChat.mockResolvedValue('local answer');
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toMatchObject({ provider: 'ollama' });
+    });
+  });
+
+  describe('Ollama', () => {
+    beforeEach(() => {
+      mockIsOllamaAvailable.mockResolvedValue(true);
+    });
+
+    it('answers with the default local model', async () => {
+      mockOllamaChat.mockResolvedValue('local answer');
+      const { generateChatAnswer } = await importProviders();
+
+      const result = await generateChatAnswer('sys', 'q');
+
+      expect(result).toEqual({
+        answer: 'local answer',
+        provider: 'ollama',
+        model: 'llama3.2',
+        usedFallbackModel: false,
+      });
+      expect(mockOllamaChat).toHaveBeenCalledWith(
+        [
+          { role: 'system', content: 'sys' },
+          { role: 'user', content: 'q' },
+        ],
+        { temperature: 0.4, maxTokens: 1000 },
+      );
+    });
+
+    it('respects OLLAMA_CHAT_MODEL', async () => {
+      process.env.OLLAMA_CHAT_MODEL = 'mistral';
+      mockOllamaChat.mockResolvedValue('local answer');
+      const { generateChatAnswer } = await importProviders();
+
+      expect(await generateChatAnswer('sys', 'q')).toMatchObject({ model: 'mistral' });
+    });
+
+    it('returns null when the completion throws', async () => {
+      mockOllamaChat.mockRejectedValue(new Error('connection reset'));
+      const { generateChatAnswer } = await importProviders();
+
+      expect(await generateChatAnswer('sys', 'q')).toBeNull();
+    });
+
+    it('returns null when the completion is empty', async () => {
+      mockOllamaChat.mockResolvedValue('');
+      const { generateChatAnswer } = await importProviders();
+
+      expect(await generateChatAnswer('sys', 'q')).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/lib/letterboxd-csv.test.ts
+++ b/src/__tests__/lib/letterboxd-csv.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import {
+  getLetterboxdMovies,
+  getLetterboxdRatings,
+  getLetterboxdWatchlist,
+  getLetterboxdStats,
+  getTopRatedMovies,
+  getRecentWatches,
+} from '@/lib/letterboxd';
+
+vi.mock('fs', () => ({
+  default: { readFileSync: vi.fn() },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logError: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+// The diary dates below use the current year where the stats need "this
+// year" entries — computed instead of hard-coded so the tests don't rot.
+const YEAR = new Date().getFullYear();
+
+const DIARY_CSV = [
+  'Date,Name,Year,Letterboxd URI,Rating,Rewatch,Tags,Watched Date',
+  `2020-01-05,Old Film,1999,https://boxd.it/old,3.5,,,2020-01-04`,
+  `${YEAR}-02-11,"Comma, The Movie",2024,https://boxd.it/comma,5,Yes,,${YEAR}-02-10`,
+  `${YEAR}-03-01,Unrated Film,2023,https://boxd.it/unrated,,,,${YEAR}-02-28`,
+  `2021-06-06,,2001,https://boxd.it/notitle,4,,,2021-06-05`,
+].join('\n');
+
+const RATINGS_CSV = [
+  'Date,Name,Year,Letterboxd URI,Rating',
+  '2020-01-05,Old Film,1999,https://boxd.it/old,3.5',
+  `${YEAR}-02-11,"Comma, The Movie",2024,https://boxd.it/comma,5`,
+  '2022-08-09,Another Great One,2010,https://boxd.it/great,5',
+  '2023-01-01,Never Scored,2015,https://boxd.it/none,',
+].join('\n');
+
+const WATCHLIST_CSV = [
+  'Date,Name,Year,Letterboxd URI',
+  '2024-05-05,Future Watch,2019,https://boxd.it/future',
+  '2024-05-06,,2020,https://boxd.it/blank',
+].join('\n');
+
+function serveCsvFixtures() {
+  mockReadFileSync.mockImplementation((filePath) => {
+    const p = String(filePath);
+    if (p.includes('diary.csv')) return DIARY_CSV;
+    if (p.includes('ratings.csv')) return RATINGS_CSV;
+    if (p.includes('watchlist.csv')) return WATCHLIST_CSV;
+    throw new Error(`ENOENT: ${p}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serveCsvFixtures();
+});
+
+describe('getLetterboxdMovies', () => {
+  it('parses diary rows including quoted titles with commas', () => {
+    const movies = getLetterboxdMovies();
+
+    expect(movies).toHaveLength(3); // the row without a Name is dropped
+    expect(movies[1]).toEqual({
+      title: 'Comma, The Movie',
+      year: '2024',
+      link: 'https://boxd.it/comma',
+      rating: 5,
+      dateWatched: `${YEAR}-02-10`,
+      isRewatch: true,
+    });
+  });
+
+  it('leaves rating null for unrated entries and isRewatch false by default', () => {
+    const movies = getLetterboxdMovies();
+    expect(movies[2]).toMatchObject({ title: 'Unrated Film', rating: null, isRewatch: false });
+    expect(movies[0]).toMatchObject({ title: 'Old Film', isRewatch: false });
+  });
+
+  it('returns an empty list when the CSV cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(getLetterboxdMovies()).toEqual([]);
+  });
+});
+
+describe('getLetterboxdRatings', () => {
+  it('returns only rated films, reading the date from the Date column', () => {
+    const rated = getLetterboxdRatings();
+
+    expect(rated.map((m) => m.title)).toEqual([
+      'Old Film',
+      'Comma, The Movie',
+      'Another Great One',
+    ]);
+    expect(rated[0].dateWatched).toBe('2020-01-05');
+  });
+
+  it('returns an empty list when the CSV cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(getLetterboxdRatings()).toEqual([]);
+  });
+});
+
+describe('getLetterboxdWatchlist', () => {
+  it('returns titled entries with no rating or watch date', () => {
+    const watchlist = getLetterboxdWatchlist();
+
+    expect(watchlist).toEqual([
+      {
+        title: 'Future Watch',
+        year: '2019',
+        link: 'https://boxd.it/future',
+        rating: null,
+        dateWatched: null,
+        isRewatch: false,
+      },
+    ]);
+  });
+
+  it('returns an empty list when the CSV cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(getLetterboxdWatchlist()).toEqual([]);
+  });
+});
+
+describe('getLetterboxdStats', () => {
+  it('aggregates totals, five-star count, this-year count, and average', () => {
+    const stats = getLetterboxdStats();
+
+    expect(stats).toEqual({
+      totalFilms: 3,
+      totalRated: 3,
+      fiveStarFilms: 2,
+      thisYearFilms: 2, // the two diary entries watched this year
+      averageRating: 4.5, // (3.5 + 5 + 5) / 3, rounded to 2 decimals
+    });
+  });
+
+  it('reports a zero average when nothing is rated', () => {
+    mockReadFileSync.mockImplementation((filePath) => {
+      if (String(filePath).includes('ratings.csv')) return 'Date,Name,Year,Letterboxd URI,Rating';
+      return DIARY_CSV;
+    });
+
+    expect(getLetterboxdStats()).toMatchObject({ totalRated: 0, averageRating: 0 });
+  });
+});
+
+describe('getTopRatedMovies', () => {
+  it('returns only five-star films', () => {
+    const top = getTopRatedMovies();
+    expect(top.map((m) => m.title)).toEqual(['Comma, The Movie', 'Another Great One']);
+  });
+
+  it('respects the limit', () => {
+    expect(getTopRatedMovies(1)).toHaveLength(1);
+  });
+});
+
+describe('getRecentWatches', () => {
+  it('sorts the diary by watch date, newest first', () => {
+    const recent = getRecentWatches();
+    expect(recent.map((m) => m.title)).toEqual([
+      'Unrated Film',
+      'Comma, The Movie',
+      'Old Film',
+    ]);
+  });
+
+  it('respects the limit', () => {
+    expect(getRecentWatches(2)).toHaveLength(2);
+  });
+});

--- a/src/__tests__/lib/ollama.test.ts
+++ b/src/__tests__/lib/ollama.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isOllamaAvailable,
+  createOllamaEmbedding,
+  createOllamaChatCompletion,
+  getEmbeddingDimensions,
+} from '@/lib/ollama';
+
+function mockFetch(impl: (...args: Parameters<typeof fetch>) => Promise<Response> | Response) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('isOllamaAvailable', () => {
+  it('returns true when the tags endpoint responds OK', async () => {
+    const fn = mockFetch(() => new Response('{}', { status: 200 }));
+    expect(await isOllamaAvailable()).toBe(true);
+    expect(fn).toHaveBeenCalledWith(
+      'http://localhost:11434/api/tags',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('returns false on a non-OK response', async () => {
+    mockFetch(() => new Response('nope', { status: 500 }));
+    expect(await isOllamaAvailable()).toBe(false);
+  });
+
+  it('returns false when the server is unreachable', async () => {
+    mockFetch(() => Promise.reject(new Error('ECONNREFUSED')));
+    expect(await isOllamaAvailable()).toBe(false);
+  });
+});
+
+describe('createOllamaEmbedding', () => {
+  it('posts the text and returns the embedding vector', async () => {
+    const fn = mockFetch(
+      () => new Response(JSON.stringify({ embedding: [0.1, 0.2, 0.3] }), { status: 200 }),
+    );
+
+    const embedding = await createOllamaEmbedding('hello world');
+
+    expect(embedding).toEqual([0.1, 0.2, 0.3]);
+    const [url, init] = fn.mock.calls[0];
+    expect(url).toBe('http://localhost:11434/api/embeddings');
+    expect(JSON.parse(init!.body as string)).toEqual({
+      model: 'nomic-embed-text',
+      prompt: 'hello world',
+    });
+  });
+
+  it('throws with the server error text on a non-OK response', async () => {
+    mockFetch(() => new Response('model not found', { status: 404 }));
+    await expect(createOllamaEmbedding('x')).rejects.toThrow(
+      'Ollama embedding failed: model not found',
+    );
+  });
+});
+
+describe('createOllamaChatCompletion', () => {
+  const OK_RESPONSE = JSON.stringify({
+    message: { role: 'assistant', content: 'an answer' },
+    done: true,
+  });
+
+  it('returns the assistant message content', async () => {
+    mockFetch(() => new Response(OK_RESPONSE, { status: 200 }));
+
+    const answer = await createOllamaChatCompletion([
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'hi' },
+    ]);
+
+    expect(answer).toBe('an answer');
+  });
+
+  it('sends the default model, temperature, and token cap when no options given', async () => {
+    const fn = mockFetch(() => new Response(OK_RESPONSE, { status: 200 }));
+
+    await createOllamaChatCompletion([{ role: 'user', content: 'hi' }]);
+
+    const body = JSON.parse(fn.mock.calls[0][1]!.body as string);
+    expect(body).toMatchObject({
+      model: 'llama3.2',
+      stream: false,
+      options: { temperature: 0.4, num_predict: 1000 },
+    });
+  });
+
+  it('honors explicit model and option overrides', async () => {
+    const fn = mockFetch(() => new Response(OK_RESPONSE, { status: 200 }));
+
+    await createOllamaChatCompletion([{ role: 'user', content: 'hi' }], {
+      model: 'mistral',
+      temperature: 0.9,
+      maxTokens: 42,
+    });
+
+    const body = JSON.parse(fn.mock.calls[0][1]!.body as string);
+    expect(body).toMatchObject({
+      model: 'mistral',
+      options: { temperature: 0.9, num_predict: 42 },
+    });
+  });
+
+  it('throws with the server error text on a non-OK response', async () => {
+    mockFetch(() => new Response('out of memory', { status: 500 }));
+    await expect(
+      createOllamaChatCompletion([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Ollama chat failed: out of memory');
+  });
+});
+
+describe('getEmbeddingDimensions', () => {
+  it('maps known models to their dimensions', () => {
+    expect(getEmbeddingDimensions('nomic-embed-text')).toBe(768);
+    expect(getEmbeddingDimensions('nomic-embed-text:latest')).toBe(768);
+    expect(getEmbeddingDimensions('all-minilm')).toBe(384);
+    expect(getEmbeddingDimensions('mxbai-embed-large')).toBe(1024);
+    expect(getEmbeddingDimensions('snowflake-arctic-embed:latest')).toBe(1024);
+  });
+
+  it('defaults unknown models to 768 (matches the database migration)', () => {
+    expect(getEmbeddingDimensions('some-new-model')).toBe(768);
+  });
+
+  it('uses the default embed model when called without arguments', () => {
+    expect(getEmbeddingDimensions()).toBe(768);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,12 +18,12 @@ export default defineConfig({
         '.next/',
       ],
       // Ratchet: set just below actual coverage so CI fails on regressions.
-      // Raise these as coverage improves (actual on 2026-07-08: 75.07/67.09/70.56/76.33).
+      // Raise these as coverage improves (actual on 2026-07-09: 84.24/74.29/78.73/85.47).
       thresholds: {
-        statements: 74,
-        branches: 66,
-        functions: 69,
-        lines: 75,
+        statements: 83,
+        branches: 73,
+        functions: 77,
+        lines: 84,
       },
     },
   },


### PR DESCRIPTION
## Summary
Tests for the four least-covered integration modules (the "next frontier" after component coverage):

- **`src/lib/ollama.ts`** (13.6% → 100%): availability probe, embeddings, chat completions with option overrides, embedding-dimension lookup — all via stubbed `fetch`
- **`src/lib/letterboxd.ts`** (23.7% → ~98%): CSV parsing including quoted fields with commas, diary/ratings/watchlist readers, stats aggregation, top-rated and recent-watch sorting — via mocked `fs`
- **`src/lib/chat/context.ts`** (28.6% → ~98%): `loadBlogContext` file resolution (`<slug>/content.mdx` vs `<slug>.mdx`), import/meta stripping, heading extraction with link flattening, 7k-char truncation, and the post-context prompt block
- **`src/lib/chat/providers.ts`** (33.3% → ~91%): the OpenAI → OpenRouter → Ollama fallback chain, per-provider model fallback, empty-completion handling, and the sticky auth-error circuit breaker that disables OpenAI for the process

Coverage ratchet raised in `vitest.config.ts`: 74/66/69/75 → **83/73/77/84** (actuals: 84.24/74.29/78.73/85.47).

## Test plan
- [x] `bun run test` — 658 tests across 71 files, all passing
- [x] `bun run test:coverage` — passes with raised thresholds
- [x] `bun run lint` / `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)