### PR TITLE
feat(blog): stage every post and declare three reading series

### DIFF
--- a/src/app/blog/abolition-isnt-what-you-think/content.mdx
+++ b/src/app/blog/abolition-isnt-what-you-think/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-01-31",
   image: "/images/blog/abolition-isnt-what-you-think.webp",
   tags: ["politics", "justice", "abolition", "philosophy"],
+  series: "The Carceral State",
+  seriesOrder: 8,
+  stage: "budding",
 }
 
 ## The straw man

--- a/src/app/blog/actual-reformation/content.mdx
+++ b/src/app/blog/actual-reformation/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2025-06-21",
   image: "/images/blog/actual-reformation.webp",
   tags: ["politics", "philosophy", "sociology"],
+  stage: "evergreen",
 };
 
 ## The limits of top-down change

--- a/src/app/blog/against-optimization/content.mdx
+++ b/src/app/blog/against-optimization/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-26",
   image: "/images/blog/against-optimization.webp",
   tags: ["philosophy", "productivity", "minimalism", "life"],
+  stage: "seedling",
 }
 
 ## Everything is optimizable (until it isn't)

--- a/src/app/blog/against-productivity-time/content.mdx
+++ b/src/app/blog/against-productivity-time/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-05-26",
   image: "/images/blog/against-productivity-time.webp",
   tags: ["time", "productivity", "philosophy", "work"],
+  stage: "seedling",
 }
 
 ## The clock is a weapon

--- a/src/app/blog/ai-art-death-of-process/content.mdx
+++ b/src/app/blog/ai-art-death-of-process/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-27",
   image: "/images/blog/ai-art-death-of-process.webp",
   tags: ["technology", "art", "AI", "creativity"],
+  stage: "budding",
 }
 
 ## The wrong argument

--- a/src/app/blog/algorithmic-culture/content.mdx
+++ b/src/app/blog/algorithmic-culture/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-08-11",
   image: "/images/blog/algorithmic-culture.webp",
   tags: ["algorithms", "culture", "media", "technology"],
+  stage: "seedling",
 }
 
 ## You didn't pick this

--- a/src/app/blog/art-technology/content.mdx
+++ b/src/app/blog/art-technology/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2025-01-10",
   image: "/images/blog/art-technology.webp",
   tags: ["art", "technology", "AI", "history"],
+  stage: "evergreen",
 };
 
 ## The "painting is dead" myth and what actually happened

--- a/src/app/blog/attention-is-not-a-resource/content.mdx
+++ b/src/app/blog/attention-is-not-a-resource/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-01-23",
   image: "/images/blog/attention-is-not-a-resource.webp",
   tags: ["philosophy", "attention", "economics", "technology"],
+  series: "The Attention Economy",
+  seriesOrder: 1,
+  stage: "budding",
 }
 
 ## The metaphor is the problem

--- a/src/app/blog/bioregionalism-thinking-like-watershed/content.mdx
+++ b/src/app/blog/bioregionalism-thinking-like-watershed/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-07-14",
   image: "/images/blog/bioregionalism-thinking-like-watershed.webp",
   tags: ["bioregionalism", "ecology", "geography", "politics"],
+  stage: "seedling",
 }
 
 ## Arbitrary lines

--- a/src/app/blog/borders-are-new/content.mdx
+++ b/src/app/blog/borders-are-new/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-01-30",
   image: "/images/blog/borders-are-new.webp",
   tags: ["politics", "immigration", "history", "geography"],
+  series: "The Carceral State",
+  seriesOrder: 3,
+  stage: "budding",
 }
 
 ## A hundred years of pretending

--- a/src/app/blog/boredom-is-a-skill/content.mdx
+++ b/src/app/blog/boredom-is-a-skill/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-02-11",
   image: "/images/blog/boredom-is-a-skill.webp",
   tags: ["philosophy", "attention", "psychology", "culture"],
+  series: "The Attention Economy",
+  seriesOrder: 4,
+  stage: "budding",
 }
 
 ## Most people would rather electrocute themselves than be alone with their thoughts

--- a/src/app/blog/bureaucratic-violence/content.mdx
+++ b/src/app/blog/bureaucratic-violence/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-12-15",
   image: "/images/blog/bureaucratic-violence.webp",
   tags: ["politics", "bureaucracy", "institutions", "violence"],
+  stage: "seedling",
 }
 
 ## The hands are clean

--- a/src/app/blog/carceral-state-working/content.mdx
+++ b/src/app/blog/carceral-state-working/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-02-05",
   image: "/images/blog/carceral-state-working.webp",
   tags: ["politics", "justice", "institutions", "united-states"],
+  series: "The Carceral State",
+  seriesOrder: 1,
+  stage: "budding",
 }
 
 ## Working as designed

--- a/src/app/blog/climate-change-labor-issue/content.mdx
+++ b/src/app/blog/climate-change-labor-issue/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-09-08",
   image: "/images/blog/climate-change-labor-issue.webp",
   tags: ["climate", "labor", "politics", "environment"],
+  series: "Labor and Organizing",
+  seriesOrder: 4,
+  stage: "seedling",
 }
 
 ## The pipeline workers aren't your enemy

--- a/src/app/blog/code-playground-demo/content.mdx
+++ b/src/app/blog/code-playground-demo/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-01-24",
   image: "/images/blog/code-playground-demo.webp",
   tags: ["tutorial", "react", "css", "javascript"],
+  stage: "budding",
 };
 
 You learn programming by reading working code and then poking at it until it breaks. So here are a few small examples you can do exactly that with: a React counter, some CSS animations, a todo list that manages real state. Copy them, change a value, see what falls over.

--- a/src/app/blog/commons-never-left/content.mdx
+++ b/src/app/blog/commons-never-left/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-09-15",
   image: "/images/blog/commons-never-left.webp",
   tags: ["commons", "economics", "property", "alternatives"],
+  stage: "budding",
 }
 
 ## A convenient myth

--- a/src/app/blog/cooperatives-actually-work/content.mdx
+++ b/src/app/blog/cooperatives-actually-work/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-09-29",
   image: "/images/blog/cooperatives-actually-work.webp",
   tags: ["economics", "cooperatives", "labor", "alternatives"],
+  series: "Labor and Organizing",
+  seriesOrder: 5,
+  stage: "budding",
 }
 
 ## The numbers don't lie

--- a/src/app/blog/cruelty-as-policy/content.mdx
+++ b/src/app/blog/cruelty-as-policy/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-11-24",
   image: "/images/blog/cruelty-as-policy.webp",
   tags: ["politics", "policy", "institutions", "united-states"],
+  series: "The Carceral State",
+  seriesOrder: 2,
+  stage: "seedling",
 }
 
 ## The quiet part out loud

--- a/src/app/blog/cyber-animism/content.mdx
+++ b/src/app/blog/cyber-animism/content.mdx
@@ -7,6 +7,7 @@ export const meta = {
   tags: ["consciousness-studies", "computational-theory-of-mind", "emergence", "ai-consciousness"],
   series: "Philosophy of Mind",
   seriesOrder: 1,
+  stage: "budding",
 };
 
 ## Software has a strange ontological status

--- a/src/app/blog/death-denial-silicon-valley/content.mdx
+++ b/src/app/blog/death-denial-silicon-valley/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-12",
   image: "/images/blog/death-denial-silicon-valley.webp",
   tags: ["technology", "philosophy", "mortality", "transhumanism"],
+  stage: "evergreen",
 }
 
 ## Peter Thiel thinks death is a bug

--- a/src/app/blog/death-of-third-places/content.mdx
+++ b/src/app/blog/death-of-third-places/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-14",
   image: "/images/blog/death-of-third-places.webp",
   tags: ["society", "urban", "community", "economics"],
+  stage: "budding",
 }
 
 ## The empty stool

--- a/src/app/blog/degrowth-isnt-primitivism/content.mdx
+++ b/src/app/blog/degrowth-isnt-primitivism/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-09-01",
   image: "/images/blog/degrowth-isnt-primitivism.webp",
   tags: ["degrowth", "economics", "environment", "sustainability"],
+  stage: "budding",
 }
 
 ## The strawman that won't die

--- a/src/app/blog/deportation-machine-no-off-switch/content.mdx
+++ b/src/app/blog/deportation-machine-no-off-switch/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-12-01",
   image: "/images/blog/deportation-machine-no-off-switch.webp",
   tags: ["politics", "immigration", "institutions", "united-states"],
+  series: "The Carceral State",
+  seriesOrder: 4,
+  stage: "seedling",
 }
 
 ## The problem with building machines

--- a/src/app/blog/digital-minimalism-beyond-basics/content.mdx
+++ b/src/app/blog/digital-minimalism-beyond-basics/content.mdx
@@ -5,8 +5,9 @@ export const meta = {
   date: "2025-01-10",
   image: "/images/blog/digital-minimalism-beyond-basics.webp",
   tags: ["digital-minimalism", "attention", "research", "productivity"],
-  series: "Digital Minimalism",
-  seriesOrder: 1,
+  series: "The Attention Economy",
+  seriesOrder: 5,
+  stage: "evergreen",
 };
 
 ## The attention economy: what research confirms

--- a/src/app/blog/due-process-already-dead/content.mdx
+++ b/src/app/blog/due-process-already-dead/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-12-08",
   image: "/images/blog/due-process-already-dead.webp",
   tags: ["politics", "civil-liberties", "constitution", "law"],
+  series: "The Carceral State",
+  seriesOrder: 6,
+  stage: "budding",
 }
 
 ## The exception swallows the rule

--- a/src/app/blog/effort-without-striving/content.mdx
+++ b/src/app/blog/effort-without-striving/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-19",
   image: "/images/blog/effort-without-striving.webp",
   tags: ["philosophy", "work", "taoism", "burnout"],
+  stage: "seedling",
 }
 
 ## The two kinds of hard

--- a/src/app/blog/expertise-social-relation/content.mdx
+++ b/src/app/blog/expertise-social-relation/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-11-03",
   image: "/images/blog/expertise-social-relation.webp",
   tags: ["epistemology", "knowledge", "power", "institutions"],
+  stage: "budding",
 }
 
 ## The recognition problem

--- a/src/app/blog/fanged-noumena/content.mdx
+++ b/src/app/blog/fanged-noumena/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2025-01-15",
   image: "/images/blog/fanged-noumena.webp",
   tags: ["philosophy", "technology", "accelerationism", "nick-land", "dark-enlightenment"],
+  stage: "evergreen",
 };
 
 ## The philosopher who "didn't survive" his own thought experiment

--- a/src/app/blog/feed-is-the-problem/content.mdx
+++ b/src/app/blog/feed-is-the-problem/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-08-04",
   image: "/images/blog/feed-is-the-problem.webp",
   tags: ["social-media", "attention", "design", "technology"],
+  series: "The Attention Economy",
+  seriesOrder: 2,
+  stage: "seedling",
 }
 
 ## The format, not the content

--- a/src/app/blog/finding-yourself-myth/content.mdx
+++ b/src/app/blog/finding-yourself-myth/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-08",
   image: "/images/blog/finding-yourself-myth.webp",
   tags: ["philosophy", "identity", "psychology", "culture"],
+  stage: "budding",
 }
 
 ## The self is not a buried treasure

--- a/src/app/blog/flow-states-not-achievements/content.mdx
+++ b/src/app/blog/flow-states-not-achievements/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-12-29",
   image: "/images/blog/flow-states-not-achievements.webp",
   tags: ["philosophy", "flow", "psychology", "productivity"],
+  stage: "seedling",
 }
 
 ## The productivity industrial complex discovers flow

--- a/src/app/blog/future-of-work/content.mdx
+++ b/src/app/blog/future-of-work/content.mdx
@@ -7,6 +7,7 @@ export const meta = {
   tags: ["ai-automation", "future-of-work", "labor-economics", "policy"],
   series: "AI and Society",
   seriesOrder: 1,
+  stage: "evergreen",
 };
 
 ## Predictions crumbled against reality

--- a/src/app/blog/gdp-terrible-measure/content.mdx
+++ b/src/app/blog/gdp-terrible-measure/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-21",
   image: "/images/blog/gdp-terrible-measure.webp",
   tags: ["economics", "policy", "measurement", "alternatives"],
+  stage: "budding",
 }
 
 ## What gets counted

--- a/src/app/blog/gig-economy-old-exploitation/content.mdx
+++ b/src/app/blog/gig-economy-old-exploitation/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-06-02",
   image: "/images/blog/gig-economy-old-exploitation.webp",
   tags: ["labor", "gig-economy", "exploitation", "economics"],
+  series: "Labor and Organizing",
+  seriesOrder: 1,
+  stage: "seedling",
 }
 
 ## Innovation in marketing only

--- a/src/app/blog/healthcare-is-infrastructure/content.mdx
+++ b/src/app/blog/healthcare-is-infrastructure/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-01",
   image: "/images/blog/healthcare-is-infrastructure.webp",
   tags: ["politics", "healthcare", "economics", "policy"],
+  stage: "budding",
 }
 
 ## You don't shop for an ambulance

--- a/src/app/blog/ice-kills-americans/content.mdx
+++ b/src/app/blog/ice-kills-americans/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-12-22",
   image: "/images/blog/ice-kills-americans.webp",
   tags: ["politics", "immigration", "civil-rights", "united-states"],
+  series: "The Carceral State",
+  seriesOrder: 5,
+  stage: "seedling",
 }
 
 ## The machine eats its own

--- a/src/app/blog/impractical-majors/content.mdx
+++ b/src/app/blog/impractical-majors/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2025-01-10",
   image: "/images/blog/impractical-majors.webp",
   tags: ["education", "economics", "philosophy", "career"],
+  stage: "evergreen",
 };
 
 ## The unemployment myth collapses under scrutiny

--- a/src/app/blog/investing-in-monero/content.mdx
+++ b/src/app/blog/investing-in-monero/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
     "Monero's cryptography keeps getting stronger while exchanges keep delisting it. Where that leaves an investor in 2026.",
   image: "/images/blog/investing-in-monero.webp",
   tags: ["cryptocurrency", "privacy", "Monero", "XMR", "regulation"],
+  stage: "budding",
 };
 
 ## The current landscape

--- a/src/app/blog/journalism-dead-long-live-journalism/content.mdx
+++ b/src/app/blog/journalism-dead-long-live-journalism/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-08-18",
   image: "/images/blog/journalism-dead-long-live-journalism.webp",
   tags: ["media", "journalism", "information", "institutions"],
+  stage: "seedling",
 }
 
 ## The obituary everyone saw coming

--- a/src/app/blog/liberation-theology-was-right/content.mdx
+++ b/src/app/blog/liberation-theology-was-right/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-06-30",
   image: "/images/blog/liberation-theology-was-right.webp",
   tags: ["religion", "theology", "politics", "liberation"],
+  stage: "seedling",
 }
 
 ## The dangerous memory

--- a/src/app/blog/libraries-are-radical/content.mdx
+++ b/src/app/blog/libraries-are-radical/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-04",
   image: "/images/blog/libraries-are-radical.webp",
   tags: ["institutions", "commons", "politics", "culture"],
+  stage: "budding",
 }
 
 ## Imagine proposing this

--- a/src/app/blog/local-food-not-elitist/content.mdx
+++ b/src/app/blog/local-food-not-elitist/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-17",
   image: "/images/blog/local-food-not-elitist.webp",
   tags: ["food", "economics", "environment", "community"],
+  stage: "budding",
 }
 
 ## The wrong question

--- a/src/app/blog/loneliness-epidemic-structural/content.mdx
+++ b/src/app/blog/loneliness-epidemic-structural/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-16",
   image: "/images/blog/loneliness-epidemic-structural.webp",
   tags: ["society", "psychology", "infrastructure", "community"],
+  stage: "budding",
 }
 
 ## You're not bad at friendship

--- a/src/app/blog/meaning-isnt-optional/content.mdx
+++ b/src/app/blog/meaning-isnt-optional/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-06-23",
   image: "/images/blog/meaning-isnt-optional.webp",
   tags: ["meaning", "philosophy", "religion", "psychology"],
+  stage: "seedling",
 }
 
 ## The illusion of neutrality

--- a/src/app/blog/meditation-industrial-complex/content.mdx
+++ b/src/app/blog/meditation-industrial-complex/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-09",
   image: "/images/blog/meditation-industrial-complex.webp",
   tags: ["philosophy", "meditation", "productivity", "capitalism"],
+  stage: "budding",
 }
 
 ## You were sold a defanged religion

--- a/src/app/blog/meritocracy-myth/content.mdx
+++ b/src/app/blog/meritocracy-myth/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-03",
   image: "/images/blog/meritocracy-myth.webp",
   tags: ["politics", "economics", "education", "class"],
+  stage: "budding",
 }
 
 ## The joke we took seriously

--- a/src/app/blog/mutual-aid-isnt-charity/content.mdx
+++ b/src/app/blog/mutual-aid-isnt-charity/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-09-22",
   image: "/images/blog/mutual-aid-isnt-charity.webp",
   tags: ["mutual-aid", "solidarity", "organizing", "politics"],
+  stage: "budding",
 }
 
 ## The confusion is intentional

--- a/src/app/blog/myth-of-neutral-tool/content.mdx
+++ b/src/app/blog/myth-of-neutral-tool/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-10-13",
   image: "/images/blog/myth-of-neutral-tool.webp",
   tags: ["technology", "philosophy", "politics", "design"],
+  stage: "seedling",
 }
 
 ## The comfortable lie

--- a/src/app/blog/nihilism-is-lazy/content.mdx
+++ b/src/app/blog/nihilism-is-lazy/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-10",
   image: "/images/blog/nihilism-is-lazy.webp",
   tags: ["philosophy", "nihilism", "meaning", "existentialism"],
+  stage: "budding",
 }
 
 ## "Nothing matters" is not a conclusion. It's a stopping point.

--- a/src/app/blog/nostalgia-political-weapon/content.mdx
+++ b/src/app/blog/nostalgia-political-weapon/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-07",
   image: "/images/blog/nostalgia-political-weapon.webp",
   tags: ["politics", "culture", "history", "psychology"],
+  stage: "budding",
 }
 
 ## The past you miss never happened

--- a/src/app/blog/open-source-sustainability-crisis/content.mdx
+++ b/src/app/blog/open-source-sustainability-crisis/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-25",
   image: "/images/blog/open-source-sustainability-crisis.webp",
   tags: ["technology", "open-source", "labor", "economics"],
+  stage: "budding",
 }
 
 ## The load-bearing volunteers

--- a/src/app/blog/platform-feudalism/content.mdx
+++ b/src/app/blog/platform-feudalism/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-10-20",
   image: "/images/blog/platform-feudalism.webp",
   tags: ["technology", "platforms", "power", "digital-rights"],
+  stage: "seedling",
 }
 
 ## The illusion of ownership

--- a/src/app/blog/privacy-in-age-of-ai/content.mdx
+++ b/src/app/blog/privacy-in-age-of-ai/content.mdx
@@ -7,6 +7,7 @@ export const meta = {
   tags: ["data-privacy", "ai-surveillance", "digital-sovereignty", "federated-learning"],
   series: "AI and Society",
   seriesOrder: 2,
+  stage: "budding",
 };
 
 ## The privacy paradox

--- a/src/app/blog/problem-with-green-capitalism/content.mdx
+++ b/src/app/blog/problem-with-green-capitalism/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-08-25",
   image: "/images/blog/problem-with-green-capitalism.webp",
   tags: ["climate", "capitalism", "environment", "economics"],
+  stage: "seedling",
 }
 
 ## The comfortable lie

--- a/src/app/blog/quantified-self-prison/content.mdx
+++ b/src/app/blog/quantified-self-prison/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2026-01-24",
   image: "/images/blog/quantified-self-prison.webp",
   tags: ["technology", "psychology", "health", "surveillance"],
+  series: "The Attention Economy",
+  seriesOrder: 3,
+  stage: "budding",
 }
 
 ## Your body has a score now

--- a/src/app/blog/rational-actor-myth/content.mdx
+++ b/src/app/blog/rational-actor-myth/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-13",
   image: "/images/blog/rational-actor-myth.webp",
   tags: ["economics", "psychology", "philosophy", "institutions"],
+  stage: "evergreen",
 }
 
 ## Nobody has ever made a decision the way economists think they do

--- a/src/app/blog/rent-seeking-eating-everything/content.mdx
+++ b/src/app/blog/rent-seeking-eating-everything/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-20",
   image: "/images/blog/rent-seeking-eating-everything.webp",
   tags: ["economics", "policy", "capitalism", "inequality"],
+  stage: "budding",
 }
 
 ## You're paying tolls on roads you already built

--- a/src/app/blog/right-to-repair-civil-right/content.mdx
+++ b/src/app/blog/right-to-repair-civil-right/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-28",
   image: "/images/blog/right-to-repair-civil-right.webp",
   tags: ["technology", "ownership", "policy", "economics"],
+  stage: "budding",
 }
 
 ## You don't own what you bought

--- a/src/app/blog/rural-america-isnt-what-you-think/content.mdx
+++ b/src/app/blog/rural-america-isnt-what-you-think/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-07-21",
   image: "/images/blog/rural-america-isnt-what-you-think.webp",
   tags: ["rural", "politics", "america", "geography"],
+  stage: "budding",
 }
 
 ## Beyond the stereotypes

--- a/src/app/blog/science-studies-for-science-lovers/content.mdx
+++ b/src/app/blog/science-studies-for-science-lovers/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-10-27",
   image: "/images/blog/science-studies-for-science-lovers.webp",
   tags: ["epistemology", "science", "philosophy", "sociology"],
+  stage: "budding",
 }
 
 ## The misunderstanding

--- a/src/app/blog/seasonal-living-isnt-nostalgia/content.mdx
+++ b/src/app/blog/seasonal-living-isnt-nostalgia/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-05-19",
   image: "/images/blog/seasonal-living-isnt-nostalgia.webp",
   tags: ["time", "seasons", "nature", "lifestyle"],
+  stage: "seedling",
 }
 
 ## Your body already knows

--- a/src/app/blog/secular-society-isnt/content.mdx
+++ b/src/app/blog/secular-society-isnt/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-07-07",
   image: "/images/blog/secular-society-isnt.webp",
   tags: ["religion", "secularism", "culture", "philosophy"],
+  stage: "seedling",
 }
 
 ## The myth of disenchantment

--- a/src/app/blog/self-hosting-is-political/content.mdx
+++ b/src/app/blog/self-hosting-is-political/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-10-06",
   image: "/images/blog/self-hosting-is-political.webp",
   tags: ["technology", "self-hosting", "autonomy", "politics"],
+  stage: "budding",
 }
 
 ## Beyond the hobby

--- a/src/app/blog/self-made-billionaire-myth/content.mdx
+++ b/src/app/blog/self-made-billionaire-myth/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-18",
   image: "/images/blog/self-made-billionaire-myth.webp",
   tags: ["economics", "class", "politics", "culture"],
+  stage: "budding",
 }
 
 ## The founding myth

--- a/src/app/blog/simulation-hypothesis/content.mdx
+++ b/src/app/blog/simulation-hypothesis/content.mdx
@@ -7,6 +7,7 @@ export const meta = {
   tags: ["philosophy", "simulation-theory", "bostrom", "consciousness"],
   series: "Philosophy of Mind",
   seriesOrder: 2,
+  stage: "evergreen",
 };
 
 ## The trilemma structure

--- a/src/app/blog/smart-home-landlord-dream/content.mdx
+++ b/src/app/blog/smart-home-landlord-dream/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-29",
   image: "/images/blog/smart-home-landlord-dream.webp",
   tags: ["technology", "housing", "ownership", "privacy"],
+  stage: "budding",
 }
 
 ## The amenity that watches you

--- a/src/app/blog/sports-last-public-ritual/content.mdx
+++ b/src/app/blog/sports-last-public-ritual/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-15",
   image: "/images/blog/sports-last-public-ritual.webp",
   tags: ["culture", "sports", "community", "ritual"],
+  stage: "budding",
 }
 
 ## Sixty thousand people feeling the same thing

--- a/src/app/blog/stopped-repairing-things/content.mdx
+++ b/src/app/blog/stopped-repairing-things/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-13",
   image: "/images/blog/stopped-repairing-things.webp",
   tags: ["economics", "culture", "environment", "design"],
+  stage: "budding",
 }
 
 ## The toaster that lasted thirty years

--- a/src/app/blog/strikes-work/content.mdx
+++ b/src/app/blog/strikes-work/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-06-16",
   image: "/images/blog/strikes-work.webp",
   tags: ["labor", "strikes", "organizing", "economics"],
+  series: "Labor and Organizing",
+  seriesOrder: 2,
+  stage: "seedling",
 }
 
 ## The inconvenient truth about labor power

--- a/src/app/blog/suburbs-are-ponzi-scheme/content.mdx
+++ b/src/app/blog/suburbs-are-ponzi-scheme/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-11",
   image: "/images/blog/suburbs-are-ponzi-scheme.webp",
   tags: ["urban", "economics", "housing", "infrastructure"],
+  stage: "budding",
 }
 
 ## The development that doesn't pay for itself

--- a/src/app/blog/surrender-is-not-giving-up/content.mdx
+++ b/src/app/blog/surrender-is-not-giving-up/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-12",
   image: "/images/blog/surrender-is-not-giving-up.webp",
   tags: ["philosophy", "stoicism", "acceptance", "growth"],
+  stage: "budding",
 }
 
 ## The problem with the word

--- a/src/app/blog/taoist-case-against-hustle-culture/content.mdx
+++ b/src/app/blog/taoist-case-against-hustle-culture/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-05",
   image: "/images/blog/taoist-case-against-hustle-culture.webp",
   tags: ["philosophy", "taoism", "hustle-culture", "burnout"],
+  stage: "budding",
 }
 
 ## The grind never stops (until you do)

--- a/src/app/blog/ubi-not-radical-enough/content.mdx
+++ b/src/app/blog/ubi-not-radical-enough/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-01-22",
   image: "/images/blog/ubi-not-radical-enough.webp",
   tags: ["economics", "policy", "politics", "alternatives"],
+  stage: "budding",
 }
 
 ## The Overton window ate your revolution

--- a/src/app/blog/understanding-ego/content.mdx
+++ b/src/app/blog/understanding-ego/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2025-01-10",
   image: "/images/blog/understanding-ego.webp",
   tags: ["psychology", "self-deception", "cognitive-bias", "identity"],
+  stage: "evergreen",
 };
 
 ## Psychology's definition of "ego"

--- a/src/app/blog/university-credentialing-machine/content.mdx
+++ b/src/app/blog/university-credentialing-machine/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-11-10",
   image: "/images/blog/university-credentialing-machine.webp",
   tags: ["education", "institutions", "credentials", "economics"],
+  stage: "budding",
 }
 
 ## The quiet transformation

--- a/src/app/blog/water-wars-coming/content.mdx
+++ b/src/app/blog/water-wars-coming/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-06",
   image: "/images/blog/water-wars-coming.webp",
   tags: ["environment", "politics", "resources", "climate"],
+  stage: "evergreen",
 }
 
 ## Stop saying "coming"

--- a/src/app/blog/why-reform-fails/content.mdx
+++ b/src/app/blog/why-reform-fails/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-11-17",
   image: "/images/blog/why-reform-fails.webp",
   tags: ["politics", "reform", "systems", "organizing"],
+  series: "The Carceral State",
+  seriesOrder: 7,
+  stage: "budding",
 }
 
 ## The reform trap

--- a/src/app/blog/why-your-city-is-expensive/content.mdx
+++ b/src/app/blog/why-your-city-is-expensive/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2025-07-28",
   image: "/images/blog/why-your-city-is-expensive.webp",
   tags: ["housing", "urban", "economics", "policy"],
+  stage: "budding",
 }
 
 ## The price tag on your life

--- a/src/app/blog/wu-wei-backwards-law/content.mdx
+++ b/src/app/blog/wu-wei-backwards-law/content.mdx
@@ -4,6 +4,7 @@ export const meta = {
   date: "2026-02-02",
   image: "/images/blog/wu-wei-backwards-law.webp",
   tags: ["philosophy", "taoism", "productivity", "wu-wei"],
+  stage: "seedling",
 }
 
 ## The paradox that breaks everything

--- a/src/app/blog/your-workplace-could-be-organized/content.mdx
+++ b/src/app/blog/your-workplace-could-be-organized/content.mdx
@@ -4,6 +4,9 @@ export const meta = {
   date: "2025-06-09",
   image: "/images/blog/your-workplace-could-be-organized.webp",
   tags: ["labor", "unions", "organizing", "work"],
+  series: "Labor and Organizing",
+  seriesOrder: 3,
+  stage: "budding",
 }
 
 ## The thing nobody tells you

--- a/src/app/blog/zorhan-mamdani-politics/content.mdx
+++ b/src/app/blog/zorhan-mamdani-politics/content.mdx
@@ -5,6 +5,7 @@ export const meta = {
   date: "2026-01-10",
   image: "/images/blog/zorhan-mamdani-politics.webp",
   tags: ["politics", "socialism", "organizing", "DSA", "new-york"],
+  stage: "budding",
 };
 
 ## From Kampala to Queens: a three-continent biography


### PR DESCRIPTION
## Summary
Acts on the garden-legibility gap: the stage/series machinery existed but the content barely used it (2/83 posts staged, 6 in series).

**Stage backfill — all 83 posts now carry a stage** (was 2):
- 12 `evergreen`, 48 `budding`, 23 `seedling`
- Classified by reading each post: argument completeness, named-source density, and original synthesis vs. derivative riff — polish and length deliberately did not count
- Judgment calls of note: `zorhan-mamdani-politics` is data-dense but tracks a sitting politician, so it's `budding` (a post that rots by design can't claim "maintained"); `investing-in-monero` likewise stays `budding` as an explicitly provisional forecast

**Series as reading arcs** (order is narrative, not chronological):
- *The Carceral State* (8): system → mechanisms → why reform fails → abolition
- *The Attention Economy* (5): diagnosis → feeds → self-tracking → boredom → practice; absorbs the former one-post "Digital Minimalism" series
- *Labor and Organizing* (5): gig work → strikes → organizing your workplace → climate → cooperatives

Remaining obvious clusters left for a future pass: Taoism/inner-life (5 posts) and urbanism/repair (~7 posts).

Note: metadata-only change — post prose untouched, so no embeddings rerun needed.

## Test plan
- [x] `bun run test` — 658 passing
- [x] `bun run lint` / `bun run typecheck` — clean
- [x] `bun run build` — all 83 meta blocks parse through the TS AST extractor

🤖 Generated with [Claude Code](https://claude.com/claude-code)